### PR TITLE
Adds support for modules built against libxposed API  101 and keep compatibility for API 100 modules

### DIFF
--- a/core/src/main/java/de/robv/android/xposed/XposedBridge.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedBridge.java
@@ -207,7 +207,7 @@ public final class XposedBridge {
             throw new IllegalArgumentException("callback should not be null!");
         }
 
-        if (!HookBridge.hookMethod(0, (Executable) hookMethod, LSPosedBridge.NativeHooker.class, callback.priority, callback)) {
+        if (!HookBridge.hookMethod(HookBridge.API_MODE_LEGACY, (Executable) hookMethod, LSPosedBridge.NativeHooker.class, callback.priority, callback)) {
             log("Failed to hook " + hookMethod);
             return null;
         }
@@ -226,7 +226,7 @@ public final class XposedBridge {
     @Deprecated
     public static void unhookMethod(Member hookMethod, XC_MethodHook callback) {
         if (hookMethod instanceof Executable) {
-            HookBridge.unhookMethod(0, (Executable) hookMethod, callback);
+            HookBridge.unhookMethod(HookBridge.API_MODE_LEGACY, (Executable) hookMethod, callback);
         }
     }
 

--- a/core/src/main/java/de/robv/android/xposed/XposedBridge.java
+++ b/core/src/main/java/de/robv/android/xposed/XposedBridge.java
@@ -133,7 +133,7 @@ public final class XposedBridge {
      * Returns the currently installed version of the Xposed framework.
      */
     public static int getXposedVersion() {
-        return XposedInterface.API;
+        return XposedInterface.LIB_API;
     }
 
     /**
@@ -207,7 +207,7 @@ public final class XposedBridge {
             throw new IllegalArgumentException("callback should not be null!");
         }
 
-        if (!HookBridge.hookMethod(false, (Executable) hookMethod, LSPosedBridge.NativeHooker.class, callback.priority, callback)) {
+        if (!HookBridge.hookMethod(0, (Executable) hookMethod, LSPosedBridge.NativeHooker.class, callback.priority, callback)) {
             log("Failed to hook " + hookMethod);
             return null;
         }
@@ -226,7 +226,7 @@ public final class XposedBridge {
     @Deprecated
     public static void unhookMethod(Member hookMethod, XC_MethodHook callback) {
         if (hookMethod instanceof Executable) {
-            HookBridge.unhookMethod(false, (Executable) hookMethod, callback);
+            HookBridge.unhookMethod(0, (Executable) hookMethod, callback);
         }
     }
 

--- a/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkCreateCLHooker.java
+++ b/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkCreateCLHooker.java
@@ -24,6 +24,7 @@ import static org.lsposed.lspd.core.ApplicationServiceClient.serviceClient;
 
 import android.annotation.SuppressLint;
 import android.app.ActivityThread;
+import android.app.AppComponentFactory;
 import android.app.LoadedApk;
 import android.content.pm.ApplicationInfo;
 import android.os.Build;
@@ -111,6 +112,12 @@ public class LoadedApkCreateCLHooker implements XposedInterface.Hooker {
                 return;
             }
 
+            var param = new PackageLoadParam(loadedApk, isFirstPackage);
+            param.setClassLoader(classLoader);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                param.setAppComponentFactory((AppComponentFactory) XposedHelpers.getObjectField(loadedApk, "mAppComponentFactory"));
+            }
+
             XC_LoadPackage.LoadPackageParam lpparam = new XC_LoadPackage.LoadPackageParam(
                     XposedBridge.sLoadedPackageCallbacks);
             lpparam.packageName = packageName;
@@ -126,44 +133,95 @@ public class LoadedApkCreateCLHooker implements XposedInterface.Hooker {
             Hookers.logD("Call handleLoadedPackage: packageName=" + lpparam.packageName + " processName=" + lpparam.processName + " isFirstPackage=" + isFirstPackage + " classLoader=" + lpparam.classLoader + " appInfo=" + lpparam.appInfo);
             XC_LoadPackage.callAll(lpparam);
 
-            LSPosedContext.callOnPackageLoaded(new XposedModuleInterface.PackageLoadedParam() {
-                @NonNull
-                @Override
-                public String getPackageName() {
-                    return loadedApk.getPackageName();
-                }
-
-                @NonNull
-                @Override
-                public ApplicationInfo getApplicationInfo() {
-                    return loadedApk.getApplicationInfo();
-                }
-
-                @NonNull
-                @Override
-                public ClassLoader getDefaultClassLoader() {
-                    try {
-                        return (ClassLoader) defaultClassLoaderField.get(loadedApk);
-                    } catch (Throwable t) {
-                        throw new IllegalStateException(t);
-                    }
-                }
-
-                @NonNull
-                @Override
-                public ClassLoader getClassLoader() {
-                    return classLoader;
-                }
-
-                @Override
-                public boolean isFirstPackage() {
-                    return isFirstPackage;
-                }
-            });
+            // fire every lifecycle callback and let each module ignore what it didn't
+            // override. API 100 modules get onPackageLoaded, API 101 modules get
+            // onPackageLoaded + onPackageReady (PackageReadyParam extends PackageLoadedParam,
+            // so one param instance serves both). tbh idk if it's the cleanest, but it keeps
+            // API 100 modules alive without a whole compat layer.
+            LSPosedContext.callOnPackageLoaded(param);
+            LSPosedContext.callOnPackageReady(param);
         } catch (Throwable t) {
             Hookers.logE("error when hooking LoadedApk#createClassLoader", t);
         } finally {
             loadedApks.remove(loadedApk);
+        }
+    }
+
+    static class PackageLoadParam implements XposedModuleInterface.PackageReadyParam {
+        private final LoadedApk loadedApk;
+        private final boolean isFirstPackage;
+        private ClassLoader classLoader;
+        private AppComponentFactory appComponentFactory;
+
+        PackageLoadParam(LoadedApk loadedApk, boolean isFirstPackage) {
+            this.loadedApk = loadedApk;
+            this.isFirstPackage = isFirstPackage;
+        }
+
+        void setClassLoader(ClassLoader classLoader) {
+            this.classLoader = classLoader;
+        }
+
+        void setAppComponentFactory(AppComponentFactory appComponentFactory) {
+            this.appComponentFactory = appComponentFactory;
+        }
+
+        @NonNull
+        @Override
+        public String getPackageName() {
+            return loadedApk.getPackageName();
+        }
+
+        @NonNull
+        @Override
+        public ApplicationInfo getApplicationInfo() {
+            return loadedApk.getApplicationInfo();
+        }
+
+        @NonNull
+        @Override
+        public ClassLoader getDefaultClassLoader() {
+            if (defaultClassLoaderField == null) {
+                // mDefaultClassLoader is API 29+ only, so fall back to the package classloader. iirc it's good enough for hooking
+                return classLoader;
+            }
+            try {
+                ClassLoader defaultClassLoader = (ClassLoader) defaultClassLoaderField.get(loadedApk);
+                if (defaultClassLoader == null) {
+                    throw new IllegalStateException("Default ClassLoader is not ready");
+                }
+                return defaultClassLoader;
+            } catch (IllegalStateException e) {
+                throw e;
+            } catch (Throwable t) {
+                throw new IllegalStateException(t);
+            }
+        }
+
+        @NonNull
+        @Override
+        public ClassLoader getClassLoader() {
+            if (classLoader == null) {
+                throw new IllegalStateException("ClassLoader is not ready");
+            }
+            return classLoader;
+        }
+
+        @Override
+        public boolean isFirstPackage() {
+            return isFirstPackage;
+        }
+
+        @NonNull
+        @Override
+        public AppComponentFactory getAppComponentFactory() {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+                throw new UnsupportedOperationException();
+            }
+            if (appComponentFactory != null) {
+                return appComponentFactory;
+            }
+            return (AppComponentFactory) XposedHelpers.getObjectField(loadedApk, "mAppComponentFactory");
         }
     }
 

--- a/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkCtorHooker.java
+++ b/core/src/main/java/org/lsposed/lspd/hooker/LoadedApkCtorHooker.java
@@ -47,6 +47,7 @@ public class LoadedApkCtorHooker implements XposedInterface.Hooker {
                 XResources.setPackageNameForResDir(packageName, loadedApk.getResDir());
             }
 
+            boolean includeCode = XposedHelpers.getBooleanField(loadedApk, "mIncludeCode");
             if (packageName.equals("android")) {
                 if (XposedInit.startsSystemServer) {
                     Hookers.logD("LoadedApk#<init> is android, skip: " + mAppDir);
@@ -54,6 +55,9 @@ public class LoadedApkCtorHooker implements XposedInterface.Hooker {
                 } else {
                     packageName = "system";
                 }
+            } else if (!includeCode) {
+                Hookers.logD("LoadedApk#<init> has no code, skip: " + mAppDir);
+                return;
             }
 
             if (!XposedInit.loadedPackagesInProcess.add(packageName)) {
@@ -65,6 +69,7 @@ public class LoadedApkCtorHooker implements XposedInterface.Hooker {
             if (Log.getStackTraceString(new Throwable()).
                     contains("android.app.ActivityThread$ApplicationThread.schedulePreload")) {
                 Hookers.logD("LoadedApk#<init> maybe oneplus's custom opt, skip");
+                XposedInit.loadedPackagesInProcess.remove(packageName);
                 return;
             }
 

--- a/core/src/main/java/org/lsposed/lspd/hooker/StartBootstrapServicesHooker.java
+++ b/core/src/main/java/org/lsposed/lspd/hooker/StartBootstrapServicesHooker.java
@@ -56,6 +56,16 @@ public class StartBootstrapServicesHooker implements XposedInterface.Hooker {
                     return HandleSystemServerProcessHooker.systemServerCL;
                 }
             });
+
+            // API 101 modules wait for onSystemServerStarting, API 100 modules for
+            // onSystemServerLoaded. dispatch both so neither API gets left out.
+            LSPosedContext.callOnSystemServerStarting(new XposedModuleInterface.SystemServerStartingParam() {
+                @Override
+                @NonNull
+                public ClassLoader getClassLoader() {
+                    return HandleSystemServerProcessHooker.systemServerCL;
+                }
+            });
         } catch (Throwable t) {
             Hookers.logE("error when hooking startBootstrapServices", t);
         }

--- a/core/src/main/java/org/lsposed/lspd/impl/LSPosedBridge.java
+++ b/core/src/main/java/org/lsposed/lspd/impl/LSPosedBridge.java
@@ -724,7 +724,9 @@ public class LSPosedBridge {
     }
 
     private static Object checkReturnType(Object result, Class<?> returnType) {
-        if (returnType != null && !HookBridge.instanceOf(result, returnType)) {
+        // IsInstanceOf always fails for primitive types (there's no instance of boolean.class),
+        // so skip the check for them like runModernAndLegacy does.
+        if (returnType != null && !returnType.isPrimitive() && !HookBridge.instanceOf(result, returnType)) {
             throw new ClassCastException(castException);
         }
         return result;

--- a/core/src/main/java/org/lsposed/lspd/impl/LSPosedBridge.java
+++ b/core/src/main/java/org/lsposed/lspd/impl/LSPosedBridge.java
@@ -520,7 +520,7 @@ public class LSPosedBridge {
 
         @Override
         public void unhook() {
-            HookBridge.unhookMethod(2, executable, hooker);
+            HookBridge.unhookMethod(HookBridge.API_MODE_101, executable, hooker);
         }
     }
 
@@ -660,7 +660,7 @@ public class LSPosedBridge {
             throw new IllegalArgumentException("hooker should not be null!");
         }
 
-        if (HookBridge.hookMethod(2, hookMethod, LSPosedBridge.NativeHooker.class, priority, hooker)) {
+        if (HookBridge.hookMethod(HookBridge.API_MODE_101, hookMethod, LSPosedBridge.NativeHooker.class, priority, hooker)) {
             return new HookHandleImpl(hookMethod, hooker);
         }
         throw new io.github.libxposed.api.error.HookFailedError("Cannot hook " + hookMethod);
@@ -816,7 +816,7 @@ public class LSPosedBridge {
         }
 
         var callback = new LSPosedBridge.HookerCallback(beforeInvocation, afterInvocation);
-        if (HookBridge.hookMethod(1, hookMethod, LSPosedBridge.NativeHooker.class, priority, callback)) {
+        if (HookBridge.hookMethod(HookBridge.API_MODE_100, hookMethod, LSPosedBridge.NativeHooker.class, priority, callback)) {
             return new XposedInterface.MethodUnhooker<>() {
                 @NonNull
                 @Override
@@ -826,7 +826,7 @@ public class LSPosedBridge {
 
                 @Override
                 public void unhook() {
-                    HookBridge.unhookMethod(1, hookMethod, callback);
+                    HookBridge.unhookMethod(HookBridge.API_MODE_100, hookMethod, callback);
                 }
             };
         }

--- a/core/src/main/java/org/lsposed/lspd/impl/LSPosedBridge.java
+++ b/core/src/main/java/org/lsposed/lspd/impl/LSPosedBridge.java
@@ -10,6 +10,11 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 import de.robv.android.xposed.XposedBridge;
 import io.github.libxposed.api.XposedInterface;
@@ -22,6 +27,7 @@ public class LSPosedBridge {
     private static final String TAG = "LSPosed-Bridge";
 
     private static final String castException = "Return value's type from hook callback does not match the hooked method";
+    private static final Object[] EMPTY_ARRAY = new Object[0];
 
     private static final Method getCause;
 
@@ -82,130 +88,670 @@ public class LSPosedBridge {
         // This method is quite critical. We should try not to use system methods to avoid
         // endless recursive
         public Object callback(Object[] args) throws Throwable {
-            LSPosedHookCallback<T> callback = new LSPosedHookCallback<>();
-
             var array = ((Object[]) params);
 
             var method = (T) array[0];
             var returnType = (Class<?>) array[1];
             var isStatic = (Boolean) array[2];
 
-            callback.method = method;
-
+            Object thisObject;
+            Object[] methodArgs;
             if (isStatic) {
-                callback.thisObject = null;
-                callback.args = args;
+                thisObject = null;
+                methodArgs = args;
             } else {
-                callback.thisObject = args[0];
-                callback.args = new Object[args.length - 1];
+                thisObject = args[0];
+                methodArgs = new Object[args.length - 1];
                 //noinspection ManualArrayCopy
                 for (int i = 0; i < args.length - 1; ++i) {
-                    callback.args[i] = args[i + 1];
+                    methodArgs[i] = args[i + 1];
                 }
             }
 
             Object[][] callbacksSnapshot = HookBridge.callbackSnapshot(HookerCallback.class, method);
             Object[] modernSnapshot = callbacksSnapshot[0];
             Object[] legacySnapshot = callbacksSnapshot[1];
+            Object[] api101Snapshot = callbacksSnapshot[2];
 
-            if (modernSnapshot.length == 0 && legacySnapshot.length == 0) {
+            if (api101Snapshot.length != 0) {
+                // API 101 hooks run as the outermost chain; the terminal proceed() falls through to
+                // the API 100 + classic dispatch, so the original method still runs exactly once.
+                var chain = new ChainImpl<>(method, returnType, api101Snapshot, thisObject, methodArgs,
+                        (chainThis, chainArgs) -> runModernAndLegacy(
+                                method, returnType, chainThis, chainArgs, modernSnapshot, legacySnapshot));
                 try {
-                    return HookBridge.invokeOriginalMethod(method, callback.thisObject, callback.args);
-                } catch (InvocationTargetException ite) {
-                    throw (Throwable) HookBridge.invokeOriginalMethod(getCause, ite);
+                    return chain.proceed();
+                } finally {
+                    chain.close();
                 }
             }
+            return runModernAndLegacy(method, returnType, thisObject, methodArgs, modernSnapshot, legacySnapshot);
+        }
+    }
 
-            Object[] ctxArray = new Object[modernSnapshot.length];
-            XposedBridge.LegacyApiSupport<T> legacy = null;
+    /**
+     * Runs the libxposed API 100 (before/after) and classic Xposed dispatch around a single
+     * invocation of the original method.
+     */
+    private static <T extends Executable> Object runModernAndLegacy(
+            T method, Class<?> returnType, Object thisObject, Object[] args,
+            Object[] modernSnapshot, Object[] legacySnapshot) throws Throwable {
+        LSPosedHookCallback<T> callback = new LSPosedHookCallback<>();
+        callback.method = method;
+        callback.thisObject = thisObject;
+        callback.args = args;
 
-            // call "before method" callbacks
-            int beforeIdx;
-            for (beforeIdx = 0; beforeIdx < modernSnapshot.length; beforeIdx++) {
-                try {
-                    var hooker = (HookerCallback) modernSnapshot[beforeIdx];
-                    if (hooker.beforeParams == 0) {
-                        ctxArray[beforeIdx] = hooker.beforeInvocation.invoke(null);
-                    } else {
-                        ctxArray[beforeIdx] = hooker.beforeInvocation.invoke(null, callback);
-                    }
-                } catch (Throwable t) {
-                    LSPosedBridge.log(t);
+        if (modernSnapshot.length == 0 && legacySnapshot.length == 0) {
+            try {
+                return HookBridge.invokeOriginalMethod(method, thisObject, args);
+            } catch (InvocationTargetException ite) {
+                throw (Throwable) HookBridge.invokeOriginalMethod(getCause, ite);
+            }
+        }
 
-                    // reset result (ignoring what the unexpectedly exiting callback did)
-                    callback.setResult(null);
-                    callback.isSkipped = false;
-                    continue;
+        Object[] ctxArray = new Object[modernSnapshot.length];
+        XposedBridge.LegacyApiSupport<T> legacy = null;
+
+        // call "before method" callbacks
+        int beforeIdx;
+        for (beforeIdx = 0; beforeIdx < modernSnapshot.length; beforeIdx++) {
+            try {
+                var hooker = (HookerCallback) modernSnapshot[beforeIdx];
+                if (hooker.beforeParams == 0) {
+                    ctxArray[beforeIdx] = hooker.beforeInvocation.invoke(null);
+                } else {
+                    ctxArray[beforeIdx] = hooker.beforeInvocation.invoke(null, callback);
                 }
+            } catch (Throwable t) {
+                LSPosedBridge.log(t);
 
-                if (callback.isSkipped) {
-                    // skip remaining "before" callbacks and corresponding "after" callbacks
-                    beforeIdx++;
-                    break;
+                // reset result (ignoring what the unexpectedly exiting callback did)
+                callback.setResult(null);
+                callback.isSkipped = false;
+                continue;
+            }
+
+            if (callback.isSkipped) {
+                // skip remaining "before" callbacks and corresponding "after" callbacks
+                beforeIdx++;
+                break;
+            }
+        }
+
+        if (!callback.isSkipped && legacySnapshot.length != 0) {
+            legacy = new XposedBridge.LegacyApiSupport<>(callback, legacySnapshot);
+            legacy.handleBefore();
+        }
+
+        // call original method if not requested otherwise
+        if (!callback.isSkipped) {
+            try {
+                var result = HookBridge.invokeOriginalMethod(method, thisObject, args);
+                callback.setResult(result);
+            } catch (InvocationTargetException e) {
+                var throwable = (Throwable) HookBridge.invokeOriginalMethod(getCause, e);
+                callback.setThrowable(throwable);
+            }
+        }
+
+        // call "after method" callbacks
+        for (int afterIdx = beforeIdx - 1; afterIdx >= 0; afterIdx--) {
+            Object lastResult = callback.getResult();
+            Throwable lastThrowable = callback.getThrowable();
+            var hooker = (HookerCallback) modernSnapshot[afterIdx];
+            try {
+                if (hooker.afterParams == 0) {
+                    hooker.afterInvocation.invoke(null);
+                } else if (hooker.afterParams == 1) {
+                    hooker.afterInvocation.invoke(null, callback);
+                } else {
+                    hooker.afterInvocation.invoke(null, callback, ctxArray[afterIdx]);
+                }
+            } catch (Throwable t) {
+                LSPosedBridge.log(t);
+
+                // reset to last result (ignoring what the unexpectedly exiting callback did)
+                if (lastThrowable == null) {
+                    callback.setResult(lastResult);
+                } else {
+                    callback.setThrowable(lastThrowable);
                 }
             }
+        }
 
-            if (!callback.isSkipped && legacySnapshot.length != 0) {
-                // TODO: Separate classloader
-                legacy = new XposedBridge.LegacyApiSupport<>(callback, legacySnapshot);
-                legacy.handleBefore();
+        if (legacy != null) {
+            legacy.handleAfter();
+        }
+
+        // return
+        var t = callback.getThrowable();
+        if (t != null) {
+            throw t;
+        } else {
+            var result = callback.getResult();
+            if (returnType != null && !returnType.isPrimitive() && !HookBridge.instanceOf(result, returnType)) {
+                throw new ClassCastException(castException);
             }
-
-            // call original method if not requested otherwise
-            if (!callback.isSkipped) {
-                try {
-                    var result = HookBridge.invokeOriginalMethod(method, callback.thisObject, callback.args);
-                    callback.setResult(result);
-                } catch (InvocationTargetException e) {
-                    var throwable = (Throwable) HookBridge.invokeOriginalMethod(getCause, e);
-                    callback.setThrowable(throwable);
-                }
-            }
-
-            // call "after method" callbacks
-            for (int afterIdx = beforeIdx - 1; afterIdx >= 0; afterIdx--) {
-                Object lastResult = callback.getResult();
-                Throwable lastThrowable = callback.getThrowable();
-                var hooker = (HookerCallback) modernSnapshot[afterIdx];
-                try {
-                    if (hooker.afterParams == 0) {
-                        hooker.afterInvocation.invoke(null);
-                    } else if (hooker.afterParams == 1) {
-                        hooker.afterInvocation.invoke(null, callback);
-                    } else {
-                        hooker.afterInvocation.invoke(null, callback, ctxArray[afterIdx]);
-                    }
-                } catch (Throwable t) {
-                    LSPosedBridge.log(t);
-
-                    // reset to last result (ignoring what the unexpectedly exiting callback did)
-                    if (lastThrowable == null) {
-                        callback.setResult(lastResult);
-                    } else {
-                        callback.setThrowable(lastThrowable);
-                    }
-                }
-            }
-
-            if (legacy != null) {
-                legacy.handleAfter();
-            }
-
-            // return
-            var t = callback.getThrowable();
-            if (t != null) {
-                throw t;
-            } else {
-                var result = callback.getResult();
-                if (returnType != null && !returnType.isPrimitive() && !HookBridge.instanceOf(result, returnType)) {
-                    throw new ClassCastException(castException);
-                }
-                return result;
-            }
+            return result;
         }
     }
 
     public static void dummyCallback() {
+    }
+
+    // libxposed API 101 hooking engine (Chain / intercept / HookBuilder)
+
+    @FunctionalInterface
+    interface ChainTail {
+        Object invoke(Object thisObject, Object[] args) throws Throwable;
+    }
+
+    static class ChainImpl<T extends Executable> implements XposedInterface.Chain {
+        private final int threadId = HookBridge.gettid();
+        private final T executable;
+        private final Class<?> returnType;
+        private final Object[] hookers;
+        private final ChainTail tail;
+        private int index = -1;
+        private boolean active = true;
+        private Object thisObject;
+        private Object[] args;
+
+        ChainImpl(T executable, Class<?> returnType, Object[] hookers,
+                  Object thisObject, Object[] args, ChainTail tail) {
+            this.executable = executable;
+            this.returnType = returnType;
+            this.hookers = hookers == null ? EMPTY_ARRAY : hookers;
+            this.thisObject = thisObject;
+            this.args = args == null ? EMPTY_ARRAY : args;
+            this.tail = tail;
+        }
+
+        void close() {
+            active = false;
+        }
+
+        private void checkActive() {
+            if (HookBridge.gettid() != threadId) {
+                throw new IllegalStateException("Chain must be accessed in the same thread as the hooked method");
+            }
+            if (!active) {
+                throw new IllegalStateException("Chain cannot be used after the interception ends");
+            }
+        }
+
+        @NonNull
+        @Override
+        public Executable getExecutable() {
+            return executable;
+        }
+
+        @Override
+        public Object getThisObject() {
+            return thisObject;
+        }
+
+        @NonNull
+        @Override
+        public List<Object> getArgs() {
+            return Collections.unmodifiableList(Arrays.asList(args));
+        }
+
+        @Override
+        public Object getArg(int index) throws IndexOutOfBoundsException, ClassCastException {
+            return args[index];
+        }
+
+        @Override
+        public Object proceed() throws Throwable {
+            checkActive();
+            var next = ++index;
+            try {
+                if (next != hookers.length) {
+                    Object result = ((XposedInterface.Hooker) hookers[next]).intercept(this);
+                    return checkReturnType(result, returnType);
+                }
+                return checkReturnType(tail.invoke(thisObject, args), returnType);
+            } finally {
+                index--;
+            }
+        }
+
+        @Override
+        public Object proceed(@NonNull Object[] args) throws Throwable {
+            var oldArgs = this.args;
+            this.args = args;
+            try {
+                return proceed();
+            } finally {
+                this.args = oldArgs;
+            }
+        }
+
+        @Override
+        public Object proceedWith(@NonNull Object thisObject) throws Throwable {
+            var oldThisObject = this.thisObject;
+            this.thisObject = thisObject;
+            try {
+                return proceed();
+            } finally {
+                this.thisObject = oldThisObject;
+            }
+        }
+
+        @Override
+        public Object proceedWith(@NonNull Object thisObject, @NonNull Object[] args) throws Throwable {
+            var oldThisObject = this.thisObject;
+            var oldArgs = this.args;
+            this.thisObject = thisObject;
+            this.args = args;
+            try {
+                return proceed();
+            } finally {
+                this.thisObject = oldThisObject;
+                this.args = oldArgs;
+            }
+        }
+    }
+
+    static class ProtectiveChain implements XposedInterface.Chain {
+        private final XposedInterface.Chain base;
+        private boolean proceeded;
+        private Object result;
+        private Throwable throwable;
+
+        ProtectiveChain(XposedInterface.Chain base) {
+            this.base = base;
+        }
+
+        @NonNull
+        @Override
+        public Executable getExecutable() {
+            return base.getExecutable();
+        }
+
+        @Override
+        public Object getThisObject() {
+            return base.getThisObject();
+        }
+
+        @NonNull
+        @Override
+        public List<Object> getArgs() {
+            return base.getArgs();
+        }
+
+        @Override
+        public Object getArg(int index) throws IndexOutOfBoundsException, ClassCastException {
+            return base.getArg(index);
+        }
+
+        @Override
+        public Object proceed() throws Throwable {
+            proceeded = true;
+            try {
+                result = base.proceed();
+                return result;
+            } catch (Throwable t) {
+                throwable = t;
+                throw t;
+            }
+        }
+
+        @Override
+        public Object proceed(@NonNull Object[] args) throws Throwable {
+            proceeded = true;
+            try {
+                result = base.proceed(args);
+                return result;
+            } catch (Throwable t) {
+                throwable = t;
+                throw t;
+            }
+        }
+
+        @Override
+        public Object proceedWith(@NonNull Object thisObject) throws Throwable {
+            proceeded = true;
+            try {
+                result = base.proceedWith(thisObject);
+                return result;
+            } catch (Throwable t) {
+                throwable = t;
+                throw t;
+            }
+        }
+
+        @Override
+        public Object proceedWith(@NonNull Object thisObject, @NonNull Object[] args) throws Throwable {
+            proceeded = true;
+            try {
+                result = base.proceedWith(thisObject, args);
+                return result;
+            } catch (Throwable t) {
+                throwable = t;
+                throw t;
+            }
+        }
+    }
+
+    static class ProtectiveHooker implements XposedInterface.Hooker {
+        private final XposedInterface context;
+        private final XposedInterface.Hooker hooker;
+
+        ProtectiveHooker(XposedInterface context, XposedInterface.Hooker hooker) {
+            this.context = context;
+            this.hooker = hooker;
+        }
+
+        @Override
+        public Object intercept(@NonNull XposedInterface.Chain chain) throws Throwable {
+            var protectiveChain = new ProtectiveChain(chain);
+            try {
+                return hooker.intercept(protectiveChain);
+            } catch (Throwable t) {
+                if (protectiveChain.throwable == t) {
+                    throw t;
+                }
+                context.log(android.util.Log.WARN, "ProtectiveHooker", "Exception in hooker", t);
+                if (!protectiveChain.proceeded) {
+                    return chain.proceed();
+                }
+                if (protectiveChain.throwable != null) {
+                    throw protectiveChain.throwable;
+                }
+                return protectiveChain.result;
+            }
+        }
+    }
+
+    static class HookBuilderImpl implements XposedInterface.HookBuilder {
+        private final XposedInterface context;
+        private final Executable executable;
+        private final XposedInterface.ExceptionMode defaultExceptionMode;
+        private int priority = XposedInterface.PRIORITY_DEFAULT;
+        private XposedInterface.ExceptionMode exceptionMode = XposedInterface.ExceptionMode.DEFAULT;
+
+        HookBuilderImpl(XposedInterface context, Executable executable,
+                        XposedInterface.ExceptionMode defaultExceptionMode) {
+            this.context = context;
+            this.executable = executable;
+            this.defaultExceptionMode = defaultExceptionMode;
+        }
+
+        @Override
+        public XposedInterface.HookBuilder setPriority(int priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        @Override
+        public XposedInterface.HookBuilder setExceptionMode(@NonNull XposedInterface.ExceptionMode mode) {
+            this.exceptionMode = mode;
+            return this;
+        }
+
+        @NonNull
+        @Override
+        public XposedInterface.HookHandle intercept(@NonNull XposedInterface.Hooker hooker) {
+            if (exceptionMode == XposedInterface.ExceptionMode.PROTECTIVE
+                    || exceptionMode == XposedInterface.ExceptionMode.DEFAULT
+                    && defaultExceptionMode == XposedInterface.ExceptionMode.PROTECTIVE) {
+                hooker = new ProtectiveHooker(context, hooker);
+            }
+            return doHook(executable, priority, hooker);
+        }
+    }
+
+    static class HookHandleImpl implements XposedInterface.HookHandle {
+        private final Executable executable;
+        private final XposedInterface.Hooker hooker;
+
+        HookHandleImpl(Executable executable, XposedInterface.Hooker hooker) {
+            this.executable = executable;
+            this.hooker = hooker;
+        }
+
+        @NonNull
+        @Override
+        public Executable getExecutable() {
+            return executable;
+        }
+
+        @Override
+        public void unhook() {
+            HookBridge.unhookMethod(2, executable, hooker);
+        }
+    }
+
+    static class BaseInvoker<T extends Executable> {
+        final T executable;
+        protected Object target;
+
+        BaseInvoker(T executable) {
+            this.executable = executable;
+            this.target = XposedInterface.Invoker.Type.Chain.FULL;
+            executable.setAccessible(true);
+        }
+
+        public Object invoke(Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException {
+            var type = (XposedInterface.Invoker.Type) target;
+            Objects.requireNonNull(type);
+            if (type instanceof XposedInterface.Invoker.Type.Origin) {
+                return HookBridge.invokeOriginalMethod(executable, thisObject, args, executable instanceof Constructor);
+            }
+            if (!(type instanceof XposedInterface.Invoker.Type.Chain chainType)) {
+                throw new IllegalStateException("Unknown invoker type");
+            }
+            return invokeChain(thisObject, args, chainType.maxPriority(), false);
+        }
+
+        public Object invokeSpecial(@NonNull Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException {
+            if (Modifier.isStatic(executable.getModifiers())) {
+                throw new IllegalArgumentException("Cannot invoke special on static method: " + executable);
+            }
+            var type = (XposedInterface.Invoker.Type) target;
+            Objects.requireNonNull(type);
+            if (type instanceof XposedInterface.Invoker.Type.Origin) {
+                try {
+                    return HookBridge.invokeSpecialMethod(executable, null, thisObject, args);
+                } catch (InstantiationException e) {
+                    throw new InstantiationError(e.getMessage());
+                }
+            }
+            if (!(type instanceof XposedInterface.Invoker.Type.Chain chainType)) {
+                throw new IllegalStateException("Unknown invoker type");
+            }
+            return invokeChain(thisObject, args, chainType.maxPriority(), true);
+        }
+
+        Object invokeChain(Object thisObject, Object[] args, int maxPriority, boolean special)
+                throws InvocationTargetException, IllegalAccessException {
+            var hookers = HookBridge.callbackSnapshot101(executable, maxPriority);
+            ChainTail tail;
+            if (special) {
+                tail = (thiz, chainArgs) -> {
+                    try {
+                        return HookBridge.invokeSpecialMethod(executable, null, thiz, chainArgs);
+                    } catch (InstantiationException e) {
+                        throw new InstantiationError(e.getMessage());
+                    }
+                };
+            } else {
+                tail = (thiz, chainArgs) -> invokeOriginal(executable, thiz, chainArgs, executable instanceof Constructor);
+            }
+            var chain = new ChainImpl<>(executable, returnTypeOf(executable), hookers, thisObject, args, tail);
+            try {
+                return chain.proceed();
+            } catch (Error | RuntimeException | InvocationTargetException | IllegalAccessException e) {
+                throw e;
+            } catch (Throwable t) {
+                throw new InvocationTargetException(t);
+            } finally {
+                chain.close();
+            }
+        }
+
+        void setInvokerType(@NonNull XposedInterface.Invoker.Type type) {
+            target = type;
+        }
+    }
+
+    static class MethodInvokerImpl extends BaseInvoker<Method> implements XposedInterface.Invoker<MethodInvokerImpl, Method> {
+        MethodInvokerImpl(Method executable) {
+            super(executable);
+        }
+
+        @Override
+        public MethodInvokerImpl setType(@NonNull XposedInterface.Invoker.Type type) {
+            setInvokerType(type);
+            return this;
+        }
+    }
+
+    static class CtorInvokerImpl<T> extends BaseInvoker<Constructor<T>> implements XposedInterface.CtorInvoker<T> {
+        CtorInvokerImpl(Constructor<T> executable) {
+            super(executable);
+        }
+
+        @NonNull
+        @Override
+        public T newInstance(Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException {
+            var instance = HookBridge.allocateObject(executable.getDeclaringClass());
+            invoke(instance, args);
+            return instance;
+        }
+
+        @NonNull
+        @Override
+        public <U> U newInstanceSpecial(@NonNull Class<U> subClass, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException {
+            var type = (XposedInterface.Invoker.Type) super.target;
+            Objects.requireNonNull(type);
+            if (type instanceof XposedInterface.Invoker.Type.Origin) {
+                return (U) HookBridge.invokeSpecialMethod(executable, subClass, null, args);
+            }
+            if (!(type instanceof XposedInterface.Invoker.Type.Chain chainType)) {
+                throw new IllegalStateException("Unknown invoker type");
+            }
+            var instance = HookBridge.allocateSpecialReceiver(executable, subClass);
+            invokeChain(instance, args, chainType.maxPriority(), true);
+            return instance;
+        }
+
+        @Override
+        public XposedInterface.CtorInvoker<T> setType(@NonNull XposedInterface.Invoker.Type type) {
+            setInvokerType(type);
+            return this;
+        }
+    }
+
+    public static XposedInterface.HookHandle doHook(
+            Executable hookMethod,
+            int priority,
+            XposedInterface.Hooker hooker
+    ) {
+        if (Modifier.isAbstract(hookMethod.getModifiers())) {
+            throw new IllegalArgumentException("Cannot hook abstract methods: " + hookMethod);
+        } else if (hookMethod.getDeclaringClass().getClassLoader() == LSPosedContext.class.getClassLoader()) {
+            throw new IllegalArgumentException("Do not allow hooking inner methods");
+        } else if (hookMethod.getDeclaringClass() == Method.class && hookMethod.getName().equals("invoke")) {
+            throw new IllegalArgumentException("Cannot hook Method.invoke");
+        } else if (hooker == null) {
+            throw new IllegalArgumentException("hooker should not be null!");
+        }
+
+        if (HookBridge.hookMethod(2, hookMethod, LSPosedBridge.NativeHooker.class, priority, hooker)) {
+            return new HookHandleImpl(hookMethod, hooker);
+        }
+        throw new io.github.libxposed.api.error.HookFailedError("Cannot hook " + hookMethod);
+    }
+
+    public static XposedInterface.HookBuilder newHookBuilder(
+            XposedInterface context,
+            Executable executable,
+            XposedInterface.ExceptionMode defaultExceptionMode
+    ) {
+        Objects.requireNonNull(executable, "origin must not be null");
+        return new HookBuilderImpl(context, executable, defaultExceptionMode);
+    }
+
+    public static XposedInterface.HookBuilder newClassInitializerHookBuilder(
+            XposedInterface context,
+            Class<?> clazz,
+            XposedInterface.ExceptionMode defaultExceptionMode
+    ) {
+        Objects.requireNonNull(clazz, "origin must not be null");
+        if (clazz.getClassLoader() == LSPosedContext.class.getClassLoader()) {
+            throw new IllegalArgumentException("Do not allow hooking inner classes");
+        }
+        synchronized (clazz) {
+            Method classInitializer = HookBridge.findClassInitializer(clazz);
+            if (classInitializer == null) {
+                throw new IllegalArgumentException("Cannot find class initializer for " + clazz);
+            }
+            return new HookBuilderImpl(context, classInitializer, defaultExceptionMode);
+        }
+    }
+
+    public static boolean doDeoptimize(@NonNull Executable executable) {
+        Objects.requireNonNull(executable, "executable must not be null");
+        if (Modifier.isAbstract(executable.getModifiers())) {
+            throw new IllegalArgumentException("Cannot deoptimize abstract methods: " + executable);
+        } else if (Proxy.isProxyClass(executable.getDeclaringClass())) {
+            throw new IllegalArgumentException("Cannot deoptimize methods from proxy class: " + executable);
+        }
+        return HookBridge.deoptimizeMethod(executable);
+    }
+
+    public static XposedInterface.Invoker<?, Method> newInvoker(@NonNull Method method) {
+        Objects.requireNonNull(method, "method must not be null");
+        return new MethodInvokerImpl(method);
+    }
+
+    public static <T> XposedInterface.CtorInvoker<T> newInvoker(@NonNull Constructor<T> constructor) {
+        Objects.requireNonNull(constructor, "constructor must not be null");
+        return new CtorInvokerImpl<>(constructor);
+    }
+
+    // libxposed API 100 hooking engine (before / after hooker classes)
+
+    private static Class<?> returnTypeOf(Executable executable) {
+        if (!(executable instanceof Method method)) {
+            return null;
+        }
+        var returnType = method.getReturnType();
+        return returnType.isPrimitive() ? null : returnType;
+    }
+
+    private static Object checkReturnType(Object result, Class<?> returnType) {
+        if (returnType != null && !HookBridge.instanceOf(result, returnType)) {
+            throw new ClassCastException(castException);
+        }
+        return result;
+    }
+
+    private static Object unwrapInvocationTarget(InvocationTargetException e) throws Throwable {
+        if (getCause == null) {
+            throw e;
+        }
+        Throwable cause = (Throwable) HookBridge.invokeOriginalMethod(getCause, e, EMPTY_ARRAY, false);
+        if (cause != null) {
+            throw cause;
+        }
+        throw e;
+    }
+
+    private static <T extends Executable> Object invokeOriginal(
+            T method,
+            Object thisObject,
+            Object[] args,
+            boolean isConstructor
+    ) throws Throwable {
+        try {
+            return HookBridge.invokeOriginalMethod(method, thisObject, args, isConstructor);
+        } catch (InvocationTargetException e) {
+            return unwrapInvocationTarget(e);
+        }
     }
 
     public static <T extends Executable> XposedInterface.MethodUnhooker<T>
@@ -268,7 +814,7 @@ public class LSPosedBridge {
         }
 
         var callback = new LSPosedBridge.HookerCallback(beforeInvocation, afterInvocation);
-        if (HookBridge.hookMethod(true, hookMethod, LSPosedBridge.NativeHooker.class, priority, callback)) {
+        if (HookBridge.hookMethod(1, hookMethod, LSPosedBridge.NativeHooker.class, priority, callback)) {
             return new XposedInterface.MethodUnhooker<>() {
                 @NonNull
                 @Override
@@ -278,7 +824,7 @@ public class LSPosedBridge {
 
                 @Override
                 public void unhook() {
-                    HookBridge.unhookMethod(true, hookMethod, callback);
+                    HookBridge.unhookMethod(1, hookMethod, callback);
                 }
             };
         }
@@ -291,11 +837,14 @@ public class LSPosedBridge {
             throw new IllegalArgumentException("Do not allow hooking inner classes");
         }
         synchronized (clazz) {
-            Constructor<T> classInitializerConstructor = HookBridge.findClassInitializer(clazz);
-            if (classInitializerConstructor == null) {
+            Method classInitializer = HookBridge.findClassInitializer(clazz);
+            if (classInitializer == null) {
                 throw new IllegalArgumentException("Cannot find class initializer for " + clazz);
             }
-            return doHook(classInitializerConstructor, priority, hooker);
+            // API 100 sees the class initializer as Constructor<T>, the native side reports a
+            // Method. the generic param is erased anyway, so the unchecked cast is safe, iirc.
+            return (XposedInterface.MethodUnhooker<Constructor<T>>) (XposedInterface.MethodUnhooker<?>)
+                    doHook(classInitializer, priority, hooker);
         }
     }
 }

--- a/core/src/main/java/org/lsposed/lspd/impl/LSPosedContext.java
+++ b/core/src/main/java/org/lsposed/lspd/impl/LSPosedContext.java
@@ -60,12 +60,27 @@ public class LSPosedContext implements XposedInterface {
     private final String mPackageName;
     private final ApplicationInfo mApplicationInfo;
     private final ILSPInjectedModuleService service;
+    private final ExceptionMode mDefaultExceptionMode;
     private final Map<String, SharedPreferences> mRemotePrefs = new ConcurrentHashMap<>();
 
-    LSPosedContext(String packageName, ApplicationInfo applicationInfo, ILSPInjectedModuleService service) {
+    LSPosedContext(String packageName, ApplicationInfo applicationInfo, ILSPInjectedModuleService service,
+                   ExceptionMode defaultExceptionMode) {
         this.mPackageName = packageName;
         this.mApplicationInfo = applicationInfo;
         this.service = service;
+        this.mDefaultExceptionMode = defaultExceptionMode;
+    }
+
+    // module lifecycle dispatch: fire every callback, modules react to what they override.
+
+    public static void callOnModuleLoaded(XposedModuleInterface.ModuleLoadedParam param) {
+        for (XposedModule module : modules) {
+            try {
+                module.onModuleLoaded(param);
+            } catch (Throwable t) {
+                Log.e(TAG, "Error when calling onModuleLoaded of " + module.getModuleApplicationInfo().packageName, t);
+            }
+        }
     }
 
     public static void callOnPackageLoaded(XposedModuleInterface.PackageLoadedParam param) {
@@ -73,7 +88,17 @@ public class LSPosedContext implements XposedInterface {
             try {
                 module.onPackageLoaded(param);
             } catch (Throwable t) {
-                Log.e(TAG, "Error when calling onPackageLoaded of " + module.getApplicationInfo().packageName, t);
+                Log.e(TAG, "Error when calling onPackageLoaded of " + module.getModuleApplicationInfo().packageName, t);
+            }
+        }
+    }
+
+    public static void callOnPackageReady(XposedModuleInterface.PackageReadyParam param) {
+        for (XposedModule module : modules) {
+            try {
+                module.onPackageReady(param);
+            } catch (Throwable t) {
+                Log.e(TAG, "Error when calling onPackageReady of " + module.getModuleApplicationInfo().packageName, t);
             }
         }
     }
@@ -83,7 +108,17 @@ public class LSPosedContext implements XposedInterface {
             try {
                 module.onSystemServerLoaded(param);
             } catch (Throwable t) {
-                Log.e(TAG, "Error when calling onSystemServerLoaded of " + module.getApplicationInfo().packageName, t);
+                Log.e(TAG, "Error when calling onSystemServerLoaded of " + module.getModuleApplicationInfo().packageName, t);
+            }
+        }
+    }
+
+    public static void callOnSystemServerStarting(XposedModuleInterface.SystemServerStartingParam param) {
+        for (XposedModule module : modules) {
+            try {
+                module.onSystemServerStarting(param);
+            } catch (Throwable t) {
+                Log.e(TAG, "Error when calling onSystemServerStarting of " + module.getModuleApplicationInfo().packageName, t);
             }
         }
     }
@@ -106,7 +141,9 @@ public class LSPosedContext implements XposedInterface {
                 Log.e(TAG, "  This may cause strange issues and must be fixed by the module developer.");
                 return false;
             }
-            var ctx = new LSPosedContext(module.packageName, module.applicationInfo, module.service);
+            module.file.moduleLibraryNames.forEach(NativeAPI::recordNativeEntrypoint);
+            var defaultExceptionMode = module.file.exceptionPassthrough ? ExceptionMode.PASSTHROUGH : ExceptionMode.PROTECTIVE;
+            var ctx = new LSPosedContext(module.packageName, module.applicationInfo, module.service, defaultExceptionMode);
             for (var entry : module.file.moduleClassNames) {
                 var moduleClass = mcl.loadClass(entry);
                 Log.d(TAG, "  Loading class " + moduleClass);
@@ -115,17 +152,39 @@ public class LSPosedContext implements XposedInterface {
                     continue;
                 }
                 try {
-                    var moduleEntry = moduleClass.getConstructor(XposedInterface.class, XposedModuleInterface.ModuleLoadedParam.class);
-                    var moduleContext = (XposedModule) moduleEntry.newInstance(ctx, new XposedModuleInterface.ModuleLoadedParam() {
+                    // API 100 modules take a (XposedInterface, ModuleLoadedParam) ctor, API 101
+                    // modules use no-arg + attachFramework. try API 100 first, fall back to
+                    // API 101, decided per module so nobody has to configure anything.
+                    XposedModule moduleContext;
+                    try {
+                        var moduleEntry = moduleClass.getConstructor(XposedInterface.class,
+                                XposedModuleInterface.ModuleLoadedParam.class);
+                        moduleContext = (XposedModule) moduleEntry.newInstance(ctx, new XposedModuleInterface.ModuleLoadedParam() {
+                            @Override
+                            public boolean isSystemServer() {
+                                return LSPosedContext.isSystemServer;
+                            }
+
+                            @NonNull
+                            @Override
+                            public String getProcessName() {
+                                return LSPosedContext.processName;
+                            }
+                        });
+                    } catch (NoSuchMethodException e) {
+                        moduleContext = (XposedModule) moduleClass.getConstructor().newInstance();
+                        moduleContext.attachFramework(ctx);
+                    }
+                    moduleContext.onModuleLoaded(new XposedModuleInterface.ModuleLoadedParam() {
                         @Override
                         public boolean isSystemServer() {
-                            return isSystemServer;
+                            return LSPosedContext.isSystemServer;
                         }
 
                         @NonNull
                         @Override
                         public String getProcessName() {
-                            return processName;
+                            return LSPosedContext.processName;
                         }
                     });
                     modules.add(moduleContext);
@@ -133,7 +192,6 @@ public class LSPosedContext implements XposedInterface {
                     Log.e(TAG, "    Failed to load class " + moduleClass, e);
                 }
             }
-            module.file.moduleLibraryNames.forEach(NativeAPI::recordNativeEntrypoint);
             Log.d(TAG, "Loaded module " + module.packageName + ": " + ctx);
         } catch (Throwable e) {
             Log.d(TAG, "Loading module " + module.packageName, e);
@@ -160,6 +218,15 @@ public class LSPosedContext implements XposedInterface {
     }
 
     @Override
+    public long getFrameworkProperties() {
+        try {
+            return service.getFrameworkProperties();
+        } catch (RemoteException e) {
+            throw new XposedFrameworkError(e);
+        }
+    }
+
+    @Override
     public int getFrameworkPrivilege() {
         try {
             return service.getFrameworkPrivilege();
@@ -167,6 +234,39 @@ public class LSPosedContext implements XposedInterface {
             return -1;
         }
     }
+
+    // Hooking (API 101)
+
+    @Override
+    @NonNull
+    public HookBuilder hook(@NonNull Executable origin) {
+        return LSPosedBridge.newHookBuilder(this, origin, mDefaultExceptionMode);
+    }
+
+    @Override
+    @NonNull
+    public HookBuilder hookClassInitializer(@NonNull Class<?> origin) {
+        return LSPosedBridge.newClassInitializerHookBuilder(this, origin, mDefaultExceptionMode);
+    }
+
+    @Override
+    public boolean deoptimize(@NonNull Executable executable) {
+        return LSPosedBridge.doDeoptimize(executable);
+    }
+
+    @NonNull
+    @Override
+    public Invoker<?, Method> getInvoker(@NonNull Method method) {
+        return LSPosedBridge.newInvoker(method);
+    }
+
+    @NonNull
+    @Override
+    public <T> CtorInvoker<T> getInvoker(@NonNull Constructor<T> constructor) {
+        return LSPosedBridge.newInvoker(constructor);
+    }
+
+    // Hooking (API 100)
 
     @Override
     @NonNull
@@ -276,6 +376,11 @@ public class LSPosedContext implements XposedInterface {
     }
 
     @Override
+    public void log(int priority, @Nullable String tag, @NonNull String msg) {
+        log(priority, tag, msg, null);
+    }
+
+    @Override
     public void log(int priority, @Nullable String tag, @NonNull String message, @Nullable Throwable throwable) {
         if (message.isEmpty() && throwable == null) {
             return;
@@ -324,6 +429,12 @@ public class LSPosedContext implements XposedInterface {
 
     @NonNull
     @Override
+    public ApplicationInfo getModuleApplicationInfo() {
+        return mApplicationInfo;
+    }
+
+    @NonNull
+    @Override
     public ApplicationInfo getApplicationInfo() {
         return mApplicationInfo;
     }
@@ -336,7 +447,7 @@ public class LSPosedContext implements XposedInterface {
             try {
                 return new LSPosedRemotePreferences(service, n);
             } catch (RemoteException e) {
-                log("Failed to get remote preferences", e);
+                log(Log.ERROR, "null", "Failed to get remote preferences", e);
                 throw new XposedFrameworkError(e);
             }
         });
@@ -348,7 +459,7 @@ public class LSPosedContext implements XposedInterface {
         try {
             return service.getRemoteFileList();
         } catch (RemoteException e) {
-            log("Failed to list remote files", e);
+            log(Log.ERROR, "null", "Failed to list remote files", e);
             throw new XposedFrameworkError(e);
         }
     }

--- a/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
+++ b/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
@@ -3,20 +3,29 @@ package org.lsposed.lspd.nativebridge;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 import dalvik.annotation.optimization.FastNative;
 
 public class HookBridge {
-    public static native boolean hookMethod(boolean useModernApi, Executable hookMethod, Class<?> hooker, int priority, Object callback);
 
-    public static native boolean unhookMethod(boolean useModernApi, Executable hookMethod, Object callback);
+    /**
+     * apiMode 0: classic Xposed API (de.robv.android.xposed) callbacks.
+     * apiMode 1: libxposed API 100 before/after hooker callbacks.
+     * apiMode 2: libxposed API 101 intercept hookers.
+     */
+    public static native boolean hookMethod(int apiMode, Executable hookMethod, Class<?> hooker, int priority, Object callback);
+
+    public static native boolean unhookMethod(int apiMode, Executable hookMethod, Object callback);
 
     public static native boolean deoptimizeMethod(Executable method);
 
     public static native <T> T allocateObject(Class<T> clazz) throws InstantiationException;
 
-    public static native <T> Constructor<T> findClassInitializer(Class<T> clazz);
+    public static native <T> T allocateSpecialReceiver(Constructor<?> constructor, Class<T> clazz) throws InstantiationException;
+
+    public static native Method findClassInitializer(Class<?> clazz);
 
     public static native Object invokeOriginalMethod(Executable method, Object thisObject, Object[] args, boolean isConstructor) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException;
 
@@ -37,5 +46,19 @@ public class HookBridge {
     @FastNative
     public static native boolean setTrusted(Object cookie);
 
+    @FastNative
+    public static native int gettid();
+
+    /**
+     * Snapshot of all registered callbacks for a hooked method.
+     * Index 0: libxposed API 100 hooker callbacks, index 1: classic Xposed callbacks,
+     * index 2: libxposed API 101 hookers.
+     */
     public static native Object[][] callbackSnapshot(Class<?> hooker_callback, Executable method);
+
+    /**
+     * Snapshot of the libxposed API 101 hookers registered for a method whose priority is
+     * not greater than {@code maxPriority}, in descending priority order.
+     */
+    public static native Object[] callbackSnapshot101(Executable method, int maxPriority);
 }

--- a/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
+++ b/core/src/main/java/org/lsposed/lspd/nativebridge/HookBridge.java
@@ -11,10 +11,15 @@ import dalvik.annotation.optimization.FastNative;
 public class HookBridge {
 
     /**
-     * apiMode 0: classic Xposed API (de.robv.android.xposed) callbacks.
-     * apiMode 1: libxposed API 100 before/after hooker callbacks.
-     * apiMode 2: libxposed API 101 intercept hookers.
+     * apiMode for {@link #hookMethod} / {@link #unhookMethod}:
+     * {@link #API_MODE_LEGACY} = classic Xposed API (de.robv.android.xposed) callbacks,
+     * {@link #API_MODE_100} = libxposed API 100 before/after hooker callbacks,
+     * {@link #API_MODE_101} = libxposed API 101 intercept hookers.
      */
+    public static final int API_MODE_LEGACY = 0;
+    public static final int API_MODE_100 = 1;
+    public static final int API_MODE_101 = 2;
+
     public static native boolean hookMethod(int apiMode, Executable hookMethod, Class<?> hooker, int priority, Object callback);
 
     public static native boolean unhookMethod(int apiMode, Executable hookMethod, Object callback);

--- a/core/src/main/jni/src/jni/hook_bridge.cpp
+++ b/core/src/main/jni/src/jni/hook_bridge.cpp
@@ -618,6 +618,12 @@ jobject NewInstance(JNIEnv *env, InvokeCache &cache, jobject constructor, jobjec
 }
 
 namespace lspd {
+
+// apiMode values mirroring HookBridge.API_MODE_* on the Java side
+constexpr int API_MODE_LEGACY = 0;
+constexpr int API_MODE_100 = 1;
+constexpr int API_MODE_101 = 2;
+
 LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, hookMethod, jint apiMode, jobject hookMethod,
                       jclass hooker, jint priority, jobject callback) {
     bool newHook = false;
@@ -658,10 +664,10 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, hookMethod, jint apiMode, jobject ho
     jobject backup = hook_item->GetBackup();
     if (!backup) return JNI_FALSE;
     JNIMonitor monitor(env, backup);
-    if (apiMode == 0) {
+    if (apiMode == API_MODE_LEGACY) {
         // classic Xposed API (de.robv.android.xposed)
         hook_item->legacy_callbacks.emplace(priority, env->NewGlobalRef(callback));
-    } else if (apiMode == 1) {
+    } else if (apiMode == API_MODE_100) {
         // libxposed API 100 HookerCallback (before/after method pair)
         hook_item->modern_callbacks.emplace(priority, env->NewGlobalRef(callback));
     } else {
@@ -681,7 +687,7 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, unhookMethod, jint apiMode, jobject 
     jobject backup = hook_item->GetBackup();
     if (!backup) return JNI_FALSE;
     JNIMonitor monitor(env, backup);
-    if (apiMode == 0) {
+    if (apiMode == API_MODE_LEGACY) {
         for (auto i = hook_item->legacy_callbacks.begin(); i != hook_item->legacy_callbacks.end(); ++i) {
             if (env->IsSameObject(i->second, callback)) {
                 env->DeleteGlobalRef(i->second);
@@ -689,7 +695,7 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, unhookMethod, jint apiMode, jobject 
                 return JNI_TRUE;
             }
         }
-    } else if (apiMode == 1) {
+    } else if (apiMode == API_MODE_100) {
         for (auto i = hook_item->modern_callbacks.begin(); i != hook_item->modern_callbacks.end(); ++i) {
             if (env->IsSameObject(i->second, callback)) {
                 env->DeleteGlobalRef(i->second);

--- a/core/src/main/jni/src/jni/hook_bridge.cpp
+++ b/core/src/main/jni/src/jni/hook_bridge.cpp
@@ -26,18 +26,18 @@
 #include <shared_mutex>
 #include <mutex>
 #include <set>
+#include <unistd.h>
 
 using namespace lsplant;
 
 namespace {
-struct ModuleCallback {
-    jmethodID before_method;
-    jmethodID after_method;
-};
-
 struct HookItem {
+    // legacy_callbacks: classic Xposed API (de.robv.android.xposed) callbacks.
+    // modern_callbacks: libxposed API 100 HookerCallback objects.
+    // api101_callbacks: libxposed API 101 XposedInterface.Hooker instances.
     std::multimap<jint, jobject, std::greater<>> legacy_callbacks;
-    std::multimap<jint, ModuleCallback, std::greater<>> modern_callbacks;
+    std::multimap<jint, jobject, std::greater<>> modern_callbacks;
+    std::multimap<jint, jobject, std::greater<>> api101_callbacks;
 private:
     std::atomic<jobject> backup {nullptr};
     static_assert(decltype(backup)::is_always_lock_free);
@@ -66,12 +66,9 @@ using SharedHashMap = phmap::parallel_flat_hash_map<K, V, Hash, Eq, Alloc, N, st
 
 SharedHashMap<jmethodID, std::unique_ptr<HookItem>> hooked_methods;
 
-jmethodID callback_ctor = nullptr;
-jfieldID before_method_field = nullptr;
-jfieldID after_method_field = nullptr;
-
 struct InvokeCache {
     jclass object_class;
+    jclass class_class;
     jclass executable_class;
     jclass method_class;
     jclass constructor_class;
@@ -99,6 +96,7 @@ struct InvokeCache {
 
     jmethodID executable_get_declaring_class;
     jmethodID executable_get_parameter_types;
+    jmethodID class_get_type_name;
     jmethodID method_get_return_type;
     jmethodID method_invoke;
     jmethodID constructor_new_instance;
@@ -148,6 +146,7 @@ InvokeCache &GetInvokeCache(JNIEnv *env) {
     static auto cache = [env] {
         InvokeCache c {};
         c.object_class = NewGlobalClassRef(env, "java/lang/Object");
+        c.class_class = NewGlobalClassRef(env, "java/lang/Class");
         c.executable_class = NewGlobalClassRef(env, "java/lang/reflect/Executable");
         c.method_class = NewGlobalClassRef(env, "java/lang/reflect/Method");
         c.constructor_class = NewGlobalClassRef(env, "java/lang/reflect/Constructor");
@@ -176,6 +175,7 @@ InvokeCache &GetInvokeCache(JNIEnv *env) {
                                                             "()Ljava/lang/Class;");
         c.executable_get_parameter_types = env->GetMethodID(c.executable_class, "getParameterTypes",
                                                             "()[Ljava/lang/Class;");
+        c.class_get_type_name = env->GetMethodID(c.class_class, "getTypeName", "()Ljava/lang/String;");
         c.method_get_return_type = env->GetMethodID(c.method_class, "getReturnType", "()Ljava/lang/Class;");
         c.method_invoke = env->GetMethodID(c.method_class, "invoke",
                                            "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;");
@@ -388,6 +388,73 @@ ScopedLocalRef<jobject> AllocateReceiver(JNIEnv *env, jclass cls) {
     return ScopedLocalRef<jobject>(env, env->AllocObject(cls));
 }
 
+void ThrowUnexpectedReceiverException(JNIEnv *env, InvokeCache &cache, jclass expected, jclass actual) {
+    ScopedLocalRef<jstring> expected_type_jstr(env, reinterpret_cast<jstring>(
+            env->CallObjectMethod(expected, cache.class_get_type_name)));
+    if (!expected_type_jstr || env->ExceptionCheck()) return;
+
+    auto expected_type = env->GetStringUTFChars(expected_type_jstr.get(), nullptr);
+    if (expected_type == nullptr || env->ExceptionCheck()) return;
+
+    ScopedLocalRef<jstring> actual_type_jstr(env, reinterpret_cast<jstring>(
+            env->CallObjectMethod(actual, cache.class_get_type_name)));
+    if (!actual_type_jstr || env->ExceptionCheck()) {
+        env->ReleaseStringUTFChars(expected_type_jstr.get(), expected_type);
+        return;
+    }
+
+    auto actual_type = env->GetStringUTFChars(actual_type_jstr.get(), nullptr);
+    if (actual_type == nullptr || env->ExceptionCheck()) {
+        env->ReleaseStringUTFChars(expected_type_jstr.get(), expected_type);
+        return;
+    }
+
+    std::array<char, 1024> msg {};
+    std::snprintf(msg.data(), msg.size(), "Expected receiver of type %s, but got %s",
+                  expected_type, actual_type);
+    env->ReleaseStringUTFChars(actual_type_jstr.get(), actual_type);
+    env->ReleaseStringUTFChars(expected_type_jstr.get(), expected_type);
+
+    Throw(env, "java/lang/IllegalArgumentException", msg.data());
+}
+
+void ThrowUnexpectedReceiverException(JNIEnv *env, InvokeCache &cache, jclass expected, jobject actual) {
+    if (actual == nullptr) {
+        Throw(env, "java/lang/IllegalArgumentException", "object is not an instance of declaring class");
+        return;
+    }
+
+    ScopedLocalRef<jclass> actual_class(env, env->GetObjectClass(actual));
+    if (!actual_class || env->ExceptionCheck()) {
+        Throw(env, "java/lang/IllegalArgumentException", "object is not an instance of declaring class");
+        return;
+    }
+
+    ThrowUnexpectedReceiverException(env, cache, expected, actual_class.get());
+}
+
+ScopedLocalRef<jobject> AllocateSpecialReceiver(JNIEnv *env, InvokeCache &cache, jobject constructor,
+                                                jclass alloc_class) {
+    if (constructor == nullptr) {
+        Throw(env, "java/lang/NullPointerException", "constructor == null");
+        return ScopedLocalRef<jobject>(env);
+    }
+    if (alloc_class == nullptr) {
+        Throw(env, "java/lang/NullPointerException", "subClass == null");
+        return ScopedLocalRef<jobject>(env);
+    }
+
+    ScopedLocalRef<jclass> declaring_class(env, (jclass) env->CallObjectMethod(
+            constructor, cache.executable_get_declaring_class));
+    if (env->ExceptionCheck()) return ScopedLocalRef<jobject>(env);
+
+    if (!env->IsAssignableFrom(alloc_class, declaring_class.get())) {
+        ThrowUnexpectedReceiverException(env, cache, declaring_class.get(), alloc_class);
+        return ScopedLocalRef<jobject>(env);
+    }
+    return AllocateReceiver(env, alloc_class);
+}
+
 jobject BoxPrimitiveResult(JNIEnv *env, InvokeCache &cache, jchar type, jvalue value) {
     switch (type) {
         case 'I':
@@ -461,9 +528,14 @@ jobject InvokeSpecial(JNIEnv *env, jobject method, jclass alloc_class, jobject t
     if (env->ExceptionCheck()) return nullptr;
 
     auto is_constructor = env->IsInstanceOf(method, cache.constructor_class);
+    if (alloc_class != nullptr && !is_constructor) {
+        Throw(env, "java/lang/IllegalArgumentException", "clazz is only supported for constructors");
+        return nullptr;
+    }
+
     ScopedLocalRef<jobject> allocated_receiver(env);
     if (thiz == nullptr && is_constructor && alloc_class != nullptr) {
-        allocated_receiver = AllocateReceiver(env, alloc_class);
+        allocated_receiver = AllocateSpecialReceiver(env, cache, method, alloc_class);
         if (env->ExceptionCheck()) return nullptr;
         thiz = allocated_receiver.get();
     }
@@ -472,7 +544,7 @@ jobject InvokeSpecial(JNIEnv *env, jobject method, jclass alloc_class, jobject t
         return nullptr;
     }
     if (!env->IsInstanceOf(thiz, declaring_class.get())) {
-        Throw(env, "java/lang/IllegalArgumentException", "object is not an instance of declaring class");
+        ThrowUnexpectedReceiverException(env, cache, declaring_class.get(), thiz);
         return nullptr;
     }
 
@@ -546,7 +618,7 @@ jobject NewInstance(JNIEnv *env, InvokeCache &cache, jobject constructor, jobjec
 }
 
 namespace lspd {
-LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, hookMethod, jboolean useModernApi, jobject hookMethod,
+LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, hookMethod, jint apiMode, jobject hookMethod,
                       jclass hooker, jint priority, jobject callback) {
     bool newHook = false;
 #ifndef NDEBUG
@@ -586,27 +658,20 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, hookMethod, jboolean useModernApi, j
     jobject backup = hook_item->GetBackup();
     if (!backup) return JNI_FALSE;
     JNIMonitor monitor(env, backup);
-    if (useModernApi) {
-        if (before_method_field == nullptr) {
-            auto callback_class = JNI_GetObjectClass(env, callback);
-            callback_ctor = JNI_GetMethodID(env, callback_class, "<init>", "(Ljava/lang/reflect/Method;Ljava/lang/reflect/Method;)V");
-            before_method_field = JNI_GetFieldID(env, callback_class, "beforeInvocation", "Ljava/lang/reflect/Method;");
-            after_method_field = JNI_GetFieldID(env, callback_class, "afterInvocation", "Ljava/lang/reflect/Method;");
-        }
-        auto before_method = JNI_GetObjectField(env, callback, before_method_field);
-        auto after_method = JNI_GetObjectField(env, callback, after_method_field);
-        auto callback_type = ModuleCallback {
-                .before_method = env->FromReflectedMethod(before_method.get()),
-                .after_method = env->FromReflectedMethod(after_method.get()),
-        };
-        hook_item->modern_callbacks.emplace(priority, callback_type);
-    } else {
+    if (apiMode == 0) {
+        // classic Xposed API (de.robv.android.xposed)
         hook_item->legacy_callbacks.emplace(priority, env->NewGlobalRef(callback));
+    } else if (apiMode == 1) {
+        // libxposed API 100 HookerCallback (before/after method pair)
+        hook_item->modern_callbacks.emplace(priority, env->NewGlobalRef(callback));
+    } else {
+        // libxposed API 101 hooker (XposedInterface.Hooker instance)
+        hook_item->api101_callbacks.emplace(priority, env->NewGlobalRef(callback));
     }
     return JNI_TRUE;
 }
 
-LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, unhookMethod, jboolean useModernApi, jobject hookMethod, jobject callback) {
+LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, unhookMethod, jint apiMode, jobject hookMethod, jobject callback) {
     auto target = env->FromReflectedMethod(hookMethod);
     HookItem * hook_item = nullptr;
     hooked_methods.if_contains(target, [&hook_item](const auto &it) {
@@ -616,20 +681,27 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, unhookMethod, jboolean useModernApi,
     jobject backup = hook_item->GetBackup();
     if (!backup) return JNI_FALSE;
     JNIMonitor monitor(env, backup);
-    if (useModernApi) {
-        auto before_method = JNI_GetObjectField(env, callback, before_method_field);
-        auto before = env->FromReflectedMethod(before_method.get());
+    if (apiMode == 0) {
+        for (auto i = hook_item->legacy_callbacks.begin(); i != hook_item->legacy_callbacks.end(); ++i) {
+            if (env->IsSameObject(i->second, callback)) {
+                env->DeleteGlobalRef(i->second);
+                hook_item->legacy_callbacks.erase(i);
+                return JNI_TRUE;
+            }
+        }
+    } else if (apiMode == 1) {
         for (auto i = hook_item->modern_callbacks.begin(); i != hook_item->modern_callbacks.end(); ++i) {
-            if (before == i->second.before_method) {
+            if (env->IsSameObject(i->second, callback)) {
+                env->DeleteGlobalRef(i->second);
                 hook_item->modern_callbacks.erase(i);
                 return JNI_TRUE;
             }
         }
     } else {
-        for (auto i = hook_item->legacy_callbacks.begin(); i != hook_item->legacy_callbacks.end(); ++i) {
+        for (auto i = hook_item->api101_callbacks.begin(); i != hook_item->api101_callbacks.end(); ++i) {
             if (env->IsSameObject(i->second, callback)) {
                 env->DeleteGlobalRef(i->second);
-                hook_item->legacy_callbacks.erase(i);
+                hook_item->api101_callbacks.erase(i);
                 return JNI_TRUE;
             }
         }
@@ -667,11 +739,20 @@ LSP_DEF_NATIVE_METHOD(jobject, HookBridge, invokeOriginalMethod, jobject hookMet
 
 LSP_DEF_NATIVE_METHOD(jobject, HookBridge, findClassInitializer, jclass cls) {
     auto clinit = env->GetStaticMethodID(cls, "<clinit>", "()V");
+    if (clinit == nullptr) {
+        env->ExceptionClear();
+        return nullptr;
+    }
     return env->ToReflectedMethod(cls, clinit, JNI_TRUE);
 }
 
 LSP_DEF_NATIVE_METHOD(jobject, HookBridge, allocateObject, jclass cls) {
     return env->AllocObject(cls);
+}
+
+LSP_DEF_NATIVE_METHOD(jobject, HookBridge, allocateSpecialReceiver, jobject constructor, jclass cls) {
+    auto &cache = GetInvokeCache(env);
+    return AllocateSpecialReceiver(env, cache, constructor, cls).release();
 }
 
 LSP_DEF_NATIVE_METHOD(jobject, HookBridge, invokeSpecialMethod, jobject method, jclass cls,
@@ -698,26 +779,57 @@ LSP_DEF_NATIVE_METHOD(jobjectArray, HookBridge, callbackSnapshot, jclass callbac
     if (!backup) return nullptr;
     JNIMonitor monitor(env, backup);
 
-    auto res = env->NewObjectArray(2, env->FindClass("[Ljava/lang/Object;"), nullptr);
+    auto res = env->NewObjectArray(3, env->FindClass("[Ljava/lang/Object;"), nullptr);
     auto modern = env->NewObjectArray((jsize) hook_item->modern_callbacks.size(), env->FindClass("java/lang/Object"), nullptr);
     auto legacy = env->NewObjectArray((jsize) hook_item->legacy_callbacks.size(), env->FindClass("java/lang/Object"), nullptr);
+    auto api101 = env->NewObjectArray((jsize) hook_item->api101_callbacks.size(), env->FindClass("java/lang/Object"), nullptr);
     for (jsize i = 0; auto callback: hook_item->modern_callbacks) {
-        auto before_method = JNI_ToReflectedMethod(env, clazz, callback.second.before_method, JNI_TRUE);
-        auto after_method = JNI_ToReflectedMethod(env, clazz, callback.second.after_method, JNI_TRUE);
-        auto callback_object = JNI_NewObject(env, callback_class, callback_ctor, before_method, after_method);
-        env->SetObjectArrayElement(modern, i++, env->NewLocalRef(callback_object.get()));
+        env->SetObjectArrayElement(modern, i++, env->NewLocalRef(callback.second));
     }
     for (jsize i = 0; auto callback: hook_item->legacy_callbacks) {
         env->SetObjectArrayElement(legacy, i++, env->NewLocalRef(callback.second));
     }
+    for (jsize i = 0; auto callback: hook_item->api101_callbacks) {
+        env->SetObjectArrayElement(api101, i++, env->NewLocalRef(callback.second));
+    }
     env->SetObjectArrayElement(res, 0, modern);
     env->SetObjectArrayElement(res, 1, legacy);
+    env->SetObjectArrayElement(res, 2, api101);
     return res;
 }
 
+LSP_DEF_NATIVE_METHOD(jobjectArray, HookBridge, callbackSnapshot101, jobject method, jint maxPriority) {
+    auto target = env->FromReflectedMethod(method);
+    auto object_class = env->FindClass("java/lang/Object");
+    HookItem *hook_item = nullptr;
+    hooked_methods.if_contains(target, [&hook_item](const auto &it) {
+        hook_item = it.second.get();
+    });
+    if (!hook_item) return env->NewObjectArray(0, object_class, nullptr);
+    jobject backup = hook_item->GetBackup();
+    if (!backup) return env->NewObjectArray(0, object_class, nullptr);
+    JNIMonitor monitor(env, backup);
+
+    jsize count = 0;
+    for (auto callback: hook_item->api101_callbacks) {
+        if (callback.first <= maxPriority) count++;
+    }
+    auto res = env->NewObjectArray(count, object_class, nullptr);
+    for (jsize i = 0; auto callback: hook_item->api101_callbacks) {
+        if (callback.first <= maxPriority) {
+            env->SetObjectArrayElement(res, i++, env->NewLocalRef(callback.second));
+        }
+    }
+    return res;
+}
+
+LSP_DEF_NATIVE_METHOD(jint, HookBridge, gettid) {
+    return gettid();
+}
+
 static JNINativeMethod gMethods[] = {
-    LSP_NATIVE_METHOD(HookBridge, hookMethod, "(ZLjava/lang/reflect/Executable;Ljava/lang/Class;ILjava/lang/Object;)Z"),
-    LSP_NATIVE_METHOD(HookBridge, unhookMethod, "(ZLjava/lang/reflect/Executable;Ljava/lang/Object;)Z"),
+    LSP_NATIVE_METHOD(HookBridge, hookMethod, "(ILjava/lang/reflect/Executable;Ljava/lang/Class;ILjava/lang/Object;)Z"),
+    LSP_NATIVE_METHOD(HookBridge, unhookMethod, "(ILjava/lang/reflect/Executable;Ljava/lang/Object;)Z"),
     LSP_NATIVE_METHOD(HookBridge, deoptimizeMethod, "(Ljava/lang/reflect/Executable;)Z"),
     LSP_NATIVE_METHOD(HookBridge, invokeOriginalMethod,
                       "(Ljava/lang/reflect/Executable;Ljava/lang/Object;[Ljava/lang/Object;Z)Ljava/lang/Object;"),
@@ -726,9 +838,14 @@ static JNINativeMethod gMethods[] = {
             "(Ljava/lang/reflect/Executable;Ljava/lang/Class;"
             "Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;"),
     LSP_NATIVE_METHOD(HookBridge, allocateObject, "(Ljava/lang/Class;)Ljava/lang/Object;"),
+    LSP_NATIVE_METHOD(HookBridge, allocateSpecialReceiver,
+                      "(Ljava/lang/reflect/Constructor;Ljava/lang/Class;)Ljava/lang/Object;"),
+    LSP_NATIVE_METHOD(HookBridge, findClassInitializer, "(Ljava/lang/Class;)Ljava/lang/reflect/Method;"),
     LSP_NATIVE_METHOD(HookBridge, instanceOf, "(Ljava/lang/Object;Ljava/lang/Class;)Z"),
+    LSP_NATIVE_METHOD(HookBridge, gettid, "()I"),
     LSP_NATIVE_METHOD(HookBridge, setTrusted, "(Ljava/lang/Object;)Z"),
     LSP_NATIVE_METHOD(HookBridge, callbackSnapshot, "(Ljava/lang/Class;Ljava/lang/reflect/Executable;)[[Ljava/lang/Object;"),
+    LSP_NATIVE_METHOD(HookBridge, callbackSnapshot101, "(Ljava/lang/reflect/Executable;I)[Ljava/lang/Object;"),
 };
 
 void RegisterHookBridge(JNIEnv *env) {

--- a/core/src/main/jni/src/jni/hook_bridge.cpp
+++ b/core/src/main/jni/src/jni/hook_bridge.cpp
@@ -670,9 +670,11 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, hookMethod, jint apiMode, jobject ho
     } else if (apiMode == API_MODE_100) {
         // libxposed API 100 HookerCallback (before/after method pair)
         hook_item->modern_callbacks.emplace(priority, env->NewGlobalRef(callback));
-    } else {
+    } else if (apiMode == API_MODE_101) {
         // libxposed API 101 hooker (XposedInterface.Hooker instance)
         hook_item->api101_callbacks.emplace(priority, env->NewGlobalRef(callback));
+    } else {
+        LOGW("Unknown apiMode {}", apiMode);
     }
     return JNI_TRUE;
 }
@@ -703,7 +705,7 @@ LSP_DEF_NATIVE_METHOD(jboolean, HookBridge, unhookMethod, jint apiMode, jobject 
                 return JNI_TRUE;
             }
         }
-    } else {
+    } else if (apiMode == API_MODE_101) {
         for (auto i = hook_item->api101_callbacks.begin(); i != hook_item->api101_callbacks.end(); ++i) {
             if (env->IsSameObject(i->second, callback)) {
                 env->DeleteGlobalRef(i->second);

--- a/daemon/build.gradle.kts
+++ b/daemon/build.gradle.kts
@@ -123,6 +123,7 @@ androidComponents.onVariants(androidComponents.selector().all()) { variant ->
 }
 
 dependencies {
+    implementation(projects.libxposed.api)
     implementation(projects.libxposed.service)
     implementation(libs.agp.apksig)
     implementation(libs.commons.lang3)

--- a/daemon/src/main/java/org/lsposed/lspd/service/ConfigFileManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/ConfigFileManager.java
@@ -70,6 +70,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
 import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -395,6 +396,49 @@ public class ConfigFileManager {
         }
     }
 
+    private static Properties readModuleProperties(ZipFile apkFile) {
+        var propEntry = apkFile.getEntry("META-INF/xposed/module.prop");
+        if (propEntry == null) return null;
+        var properties = new Properties();
+        try (var in = apkFile.getInputStream(propEntry)) {
+            properties.load(in);
+            return properties;
+        } catch (IOException e) {
+            Log.e(TAG, "Can not open " + propEntry, e);
+            return null;
+        }
+    }
+
+    private static int readApiVersion(Properties properties, String key) {
+        var value = properties.getProperty(key);
+        if (value == null || value.trim().isEmpty()) {
+            return 0;
+        }
+        value = value.trim();
+        int result = 0;
+        int length = value.length();
+        int offset = 0;
+        for (; offset < length; offset++) {
+            char c = value.charAt(offset);
+            if ('0' <= c && c <= '9') {
+                result = result * 10 + (c - '0');
+            } else {
+                break;
+            }
+        }
+        if (offset == 0) {
+            return 0;
+        }
+        return result;
+    }
+
+    private static boolean isExceptionPassthrough(Properties properties) {
+        if (properties == null) {
+            return false;
+        }
+        return "passthrough".equals(properties.getProperty("exceptionMode", "").trim());
+    }
+
     @Nullable
     static PreLoadedApk loadModule(String path, boolean obfuscate) {
         if (path == null) return null;
@@ -404,6 +448,11 @@ public class ConfigFileManager {
         var moduleLibraryNames = new ArrayList<String>(1);
         try (var apkFile = new ZipFile(toGlobalNamespace(path))) {
             readDexes(apkFile, preLoadedDexes, obfuscate);
+            var properties = readModuleProperties(apkFile);
+            // module's minApiVersion exceeds the libxposed API we implement, so skip it.
+            if (properties != null && readApiVersion(properties, "minApiVersion") > LSPModuleService.XPOSED_API_VERSION) {
+                return null;
+            }
             readName(apkFile, "META-INF/xposed/java_init.list", moduleClassNames);
             if (moduleClassNames.isEmpty()) {
                 file.legacy = true;
@@ -412,6 +461,12 @@ public class ConfigFileManager {
             } else {
                 file.legacy = false;
                 readName(apkFile, "META-INF/xposed/native_init.list", moduleLibraryNames);
+                file.exceptionPassthrough = isExceptionPassthrough(properties);
+                if (properties != null) {
+                    // libxposed API version the module was built against. API 100 modules
+                    // don't declare it, so 0 means "speaks API 100" (LSPModuleService#speaksApi101)
+                    file.targetApiVersion = readApiVersion(properties, "targetApiVersion");
+                }
             }
         } catch (IOException e) {
             Log.e(TAG, "Can not open " + path, e);

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPInjectedModuleService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPInjectedModuleService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.github.libxposed.api.XposedInterface;
 import io.github.libxposed.service.IXposedService;
 
 public class LSPInjectedModuleService extends ILSPInjectedModuleService.Stub {
@@ -32,6 +33,15 @@ public class LSPInjectedModuleService extends ILSPInjectedModuleService.Stub {
     @Override
     public int getFrameworkPrivilege() {
         return IXposedService.FRAMEWORK_PRIVILEGE_ROOT;
+    }
+
+    @Override
+    public long getFrameworkProperties() {
+        var properties = XposedInterface.PROP_CAP_SYSTEM | XposedInterface.PROP_CAP_REMOTE;
+        if (ConfigManager.getInstance().dexObfuscate()) {
+            properties |= XposedInterface.PROP_RT_API_PROTECTION;
+        }
+        return properties;
     }
 
     @Override

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPManagerService.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import hidden.HiddenApiBridge;
-import io.github.libxposed.service.IXposedService;
 import rikka.parcelablelist.ParcelableListSlice;
 
 public class LSPManagerService extends ILSPManagerService.Stub {
@@ -281,7 +280,7 @@ public class LSPManagerService extends ILSPManagerService.Stub {
 
     @Override
     public int getXposedApiVersion() {
-        return IXposedService.API;
+        return LSPModuleService.XPOSED_API_VERSION;
     }
 
     @Override

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
@@ -398,8 +398,10 @@ public class LSPModuleService extends IXposedService.Stub {
                 if (!ConfigManager.getInstance().removeModuleScope(loadedModule.packageName, packageName, userId)) {
                     throw new RemoteException("Invalid request");
                 }
+            } catch (RemoteException remote) {
+                throw remote;
             } catch (Throwable e) {
-                throw new RemoteException(e.getMessage());
+                throw new RemoteException(e.getMessage(), e);
             }
         }
     }

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
@@ -401,7 +401,9 @@ public class LSPModuleService extends IXposedService.Stub {
             } catch (RemoteException remote) {
                 throw remote;
             } catch (Throwable e) {
-                throw new RemoteException(e.getMessage(), e);
+                var re = new RemoteException(e.getMessage());
+                re.initCause(e);
+                throw re;
             }
         }
     }

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
@@ -25,6 +25,7 @@ import android.content.AttributionSource;
 import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcel;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
 import android.util.ArrayMap;
@@ -47,10 +48,15 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import io.github.libxposed.api.XposedInterface;
 import io.github.libxposed.service.IXposedScopeCallback;
 import io.github.libxposed.service.IXposedService;
 
 public class LSPModuleService extends IXposedService.Stub {
+
+    // Highest libxposed API version implemented by this framework. Modules declaring a
+    // higher minApiVersion are rejected at load time (see ConfigFileManager#loadModule).
+    static final int XPOSED_API_VERSION = XposedInterface.LIB_API;
 
     private final static String TAG = "LSPosedModuleService";
 
@@ -219,10 +225,73 @@ public class LSPModuleService extends IXposedService.Stub {
         return Binder.getCallingUid() / PER_USER_RANGE;
     }
 
+    // dual-wire dispatch (API 100 vs API 101)
+    //
+    // the IXposedService AIDL reused the same transaction codes across APIs
+    // but slapped different methods on 5/11/12:
+    //   5  = getFrameworkPrivilege (int)  in 100, getFrameworkProperties (long) in 101
+    //   11 = requestScope(String)          in 100, requestScope(List)          in 101
+    //   12 = removeScope(String)->String   in 100, removeScope(List)->void     in 101
+    // codes 1-4, 10 and 20-32 are type-compatible, so the generated stub keeps
+    // handling those. which wire a module speaks comes from module.prop
+    // targetApiVersion (API 100 modules don't declare it), so they keep working
+    // untouched. tbh idk if this survives the next API bump, but it's the only
+    // way to serve both APIs right now.
+
+    private static final int TRANSACTION_GET_FRAMEWORK_PRIVILEGE = 5;
+    private static final int TRANSACTION_REQUEST_SCOPE = 11;
+    private static final int TRANSACTION_REMOVE_SCOPE = 12;
+
+    private boolean speaksApi101() {
+        return loadedModule.file != null && loadedModule.file.targetApiVersion >= 101;
+    }
+
+    @Override
+    public boolean onTransact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
+        switch (code) {
+            case TRANSACTION_GET_FRAMEWORK_PRIVILEGE:
+                data.enforceInterface(getInterfaceDescriptor());
+                if (speaksApi101()) {
+                    reply.writeNoException();
+                    reply.writeLong(getFrameworkProperties());
+                } else {
+                    reply.writeNoException();
+                    reply.writeInt(getFrameworkPrivilege());
+                }
+                return true;
+            case TRANSACTION_REQUEST_SCOPE:
+                data.enforceInterface(getInterfaceDescriptor());
+                if (speaksApi101()) {
+                    var packages = data.createStringArrayList();
+                    var callback = IXposedScopeCallback.Stub.asInterface(data.readStrongBinder());
+                    requestScope(packages, callback);
+                } else {
+                    var packageName = data.readString();
+                    var callback = IXposedScopeCallback.Stub.asInterface(data.readStrongBinder());
+                    requestScope(packageName, callback);
+                }
+                return true;
+            case TRANSACTION_REMOVE_SCOPE:
+                data.enforceInterface(getInterfaceDescriptor());
+                if (speaksApi101()) {
+                    var packages = data.createStringArrayList();
+                    removeScope(packages);
+                    reply.writeNoException();
+                } else {
+                    var packageName = data.readString();
+                    reply.writeNoException();
+                    reply.writeString(removeScope(packageName));
+                }
+                return true;
+            default:
+                return super.onTransact(code, data, reply, flags);
+        }
+    }
+
     @Override
     public int getAPIVersion() throws RemoteException {
         ensureModule();
-        return API;
+        return XPOSED_API_VERSION;
     }
 
     @Override
@@ -249,6 +318,16 @@ public class LSPModuleService extends IXposedService.Stub {
         return IXposedService.FRAMEWORK_PRIVILEGE_ROOT;
     }
 
+    // API 101 wire: framework capabilities as a bitmask (XposedInterface#PROP_*)
+    long getFrameworkProperties() throws RemoteException {
+        ensureModule();
+        var properties = XposedInterface.PROP_CAP_SYSTEM | XposedInterface.PROP_CAP_REMOTE;
+        if (ConfigManager.getInstance().dexObfuscate()) {
+            properties |= XposedInterface.PROP_RT_API_PROTECTION;
+        }
+        return properties;
+    }
+
     @Override
     public List<String> getScope() throws RemoteException {
         ensureModule();
@@ -267,8 +346,29 @@ public class LSPModuleService extends IXposedService.Stub {
         if (ConfigManager.getInstance().scopeRequestBlocked(loadedModule.packageName)) {
             callback.onScopeRequestDenied(packageName);
         } else {
-            LSPNotificationManager.requestModuleScope(loadedModule.packageName, userId, packageName, callback);
+            LSPNotificationManager.requestModuleScope(loadedModule.packageName, userId, packageName, callback, false);
             callback.onScopeRequestPrompted(packageName);
+        }
+    }
+
+    // API 101 wire: bulk scope request. reuses the per-package notification flow of
+    // API 100, only the callback delivery differs (onScopeRequestApproved(List) /
+    // onScopeRequestFailed(String)). could've ported irena's bulk notification, but
+    // that'd mean rewriting the whole intent plumbing for little gain.
+    void requestScope(List<String> packages, IXposedScopeCallback callback) throws RemoteException {
+        Objects.requireNonNull(packages, "packages cannot be null");
+        Objects.requireNonNull(callback, "callback cannot be null");
+        var userId = ensureModule();
+        if (packages.isEmpty()) {
+            LSPNotificationManager.notifyScopeRequestFailed(callback, true, null, "Invalid request");
+            return;
+        }
+        if (ConfigManager.getInstance().scopeRequestBlocked(loadedModule.packageName)) {
+            LSPNotificationManager.notifyScopeRequestFailed(callback, true, null, "Blocked by user");
+            return;
+        }
+        for (var packageName : packages) {
+            LSPNotificationManager.requestModuleScope(loadedModule.packageName, userId, packageName, callback, true);
         }
     }
 
@@ -282,6 +382,22 @@ public class LSPModuleService extends IXposedService.Stub {
             return null;
         } catch (Throwable e) {
             return e.getMessage();
+        }
+    }
+
+    // API 101 wire: bulk scope removal. the wire returns void, so errors come back
+    // as a RemoteException instead of an error string.
+    void removeScope(List<String> packages) throws RemoteException {
+        Objects.requireNonNull(packages, "packages cannot be null");
+        var userId = ensureModule();
+        for (var packageName : packages) {
+            try {
+                if (!ConfigManager.getInstance().removeModuleScope(loadedModule.packageName, packageName, userId)) {
+                    throw new RemoteException("Invalid request");
+                }
+            } catch (Throwable e) {
+                throw new RemoteException(e.getMessage());
+            }
         }
     }
 

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPModuleService.java
@@ -227,20 +227,23 @@ public class LSPModuleService extends IXposedService.Stub {
 
     // dual-wire dispatch (API 100 vs API 101)
     //
-    // the IXposedService AIDL reused the same transaction codes across APIs
-    // but slapped different methods on 5/11/12:
-    //   5  = getFrameworkPrivilege (int)  in 100, getFrameworkProperties (long) in 101
-    //   11 = requestScope(String)          in 100, requestScope(List)          in 101
-    //   12 = removeScope(String)->String   in 100, removeScope(List)->void     in 101
-    // codes 1-4, 10 and 20-32 are type-compatible, so the generated stub keeps
-    // handling those. which wire a module speaks comes from module.prop
-    // targetApiVersion (API 100 modules don't declare it), so they keep working
-    // untouched. tbh idk if this survives the next API bump, but it's the only
-    // way to serve both APIs right now.
+    // the IXposedService AIDL reused the same transaction codes across APIs but
+    // slapped different methods on the privilege/properties and scope calls:
+    //   6  = getFrameworkPrivilege (int) in 100, getFrameworkProperties (long) in 101
+    //   12 = requestScope(String)         in 100, requestScope(List)          in 101
+    //   13 = removeScope(String)->String  in 100, removeScope(List)->void     in 101
+    // note the codes are the AIDL-declared values + 1: the AGP aidl compiler
+    // maps `= N` to FIRST_CALL_TRANSACTION + N, and both the daemon and every
+    // module are built with it, so the wire agrees (a module's getScope really
+    // arrives as 11). codes 2-5, 11 and 21-33 are type-compatible, so the
+    // generated stub keeps handling those. which wire a module speaks comes
+    // from module.prop targetApiVersion (API 100 modules don't declare it), so
+    // they keep working untouched. tbh idk if this survives the next API bump,
+    // but it's the only way to serve both APIs right now.
 
-    private static final int TRANSACTION_GET_FRAMEWORK_PRIVILEGE = 5;
-    private static final int TRANSACTION_REQUEST_SCOPE = 11;
-    private static final int TRANSACTION_REMOVE_SCOPE = 12;
+    private static final int TRANSACTION_GET_FRAMEWORK_PRIVILEGE = 6;
+    private static final int TRANSACTION_REQUEST_SCOPE = 12;
+    private static final int TRANSACTION_REMOVE_SCOPE = 13;
 
     private boolean speaksApi101() {
         return loadedModule.file != null && loadedModule.file.targetApiVersion >= 101;

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPNotificationManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPNotificationManager.java
@@ -19,9 +19,11 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.Icon;
 import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
+import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.os.Parcel;
 import android.os.RemoteException;
 import android.util.Log;
 
@@ -30,6 +32,7 @@ import org.lsposed.lspd.util.FakeContext;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -230,15 +233,74 @@ public class LSPNotificationManager {
         return PendingIntent.getBroadcast(new FakeContext(), 3, intent, flags);
     }
 
-    private static PendingIntent getModuleScopeIntent(String modulePackageName, int moduleUserId, String scopePackageName, String action, IXposedScopeCallback callback) {
+    private static PendingIntent getModuleScopeIntent(String modulePackageName, int moduleUserId, String scopePackageName, String action, IXposedScopeCallback callback, boolean api101) {
         var intent = new Intent(moduleScope);
         intent.setPackage("android");
         intent.setData(new Uri.Builder().scheme("module").encodedAuthority(modulePackageName + ":" + moduleUserId).encodedPath(scopePackageName).appendQueryParameter("action", action).build());
         var extras = new Bundle();
         extras.putBinder("callback", callback.asBinder());
+        extras.putBoolean("api101", api101);
         intent.putExtras(extras);
         int flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
         return PendingIntent.getBroadcast(new FakeContext(), 4, intent, flags);
+    }
+
+    private static final String SCOPE_CALLBACK_DESCRIPTOR = "io.github.libxposed.service.IXposedScopeCallback";
+    // API 101 IXposedScopeCallback transaction codes. these collide with the API 100
+    // ones, so we can't just call the interface directly (see notifyScopeRequest* below):
+    //   1 = onScopeRequestApproved(List<String>), 2 = onScopeRequestFailed(String)
+    private static final int SCOPE_CALLBACK_APPROVED_TRANSACTION = 1;
+    private static final int SCOPE_CALLBACK_FAILED_TRANSACTION = 2;
+
+    // deliver scope results on the wire the module was built with. API 100 modules get
+    // per-package callbacks (approved/denied/timeout/failed with a package name),
+    // API 101 modules get onScopeRequestApproved(List) and onScopeRequestFailed(String).
+    // the 101 codes collide with the 100 ones, so those parcels are built by hand.
+    // tbh it's ugly, but the daemon still compiles against the API 100 AIDL.
+    static void notifyScopeRequestApproved(IXposedScopeCallback callback, boolean api101, String scopePackageName) throws RemoteException {
+        if (api101) {
+            var data = Parcel.obtain();
+            try {
+                data.writeInterfaceToken(SCOPE_CALLBACK_DESCRIPTOR);
+                data.writeStringList(List.of(scopePackageName));
+                callback.asBinder().transact(SCOPE_CALLBACK_APPROVED_TRANSACTION, data, null, Binder.FLAG_ONEWAY);
+            } finally {
+                data.recycle();
+            }
+        } else {
+            callback.onScopeRequestApproved(scopePackageName);
+        }
+    }
+
+    static void notifyScopeRequestFailed(IXposedScopeCallback callback, boolean api101, String scopePackageName, String message) throws RemoteException {
+        if (api101) {
+            var data = Parcel.obtain();
+            try {
+                data.writeInterfaceToken(SCOPE_CALLBACK_DESCRIPTOR);
+                data.writeString(message);
+                callback.asBinder().transact(SCOPE_CALLBACK_FAILED_TRANSACTION, data, null, Binder.FLAG_ONEWAY);
+            } finally {
+                data.recycle();
+            }
+        } else {
+            callback.onScopeRequestFailed(scopePackageName, message);
+        }
+    }
+
+    static void notifyScopeRequestDenied(IXposedScopeCallback callback, boolean api101, String scopePackageName, String message101) throws RemoteException {
+        if (api101) {
+            notifyScopeRequestFailed(callback, true, scopePackageName, message101);
+        } else {
+            callback.onScopeRequestDenied(scopePackageName);
+        }
+    }
+
+    static void notifyScopeRequestTimeout(IXposedScopeCallback callback, boolean api101, String scopePackageName, String message101) throws RemoteException {
+        if (api101) {
+            notifyScopeRequestFailed(callback, true, scopePackageName, message101);
+        } else {
+            callback.onScopeRequestTimeout(scopePackageName);
+        }
     }
 
     private static String getNotificationIdKey(String channel, String modulePackageName, int moduleUserId) {
@@ -295,7 +357,7 @@ public class LSPNotificationManager {
         }
     }
 
-    static void requestModuleScope(String modulePackageName, int moduleUserId, String scopePackageName, IXposedScopeCallback callback) {
+    static void requestModuleScope(String modulePackageName, int moduleUserId, String scopePackageName, IXposedScopeCallback callback, boolean api101) {
         var context = new FakeContext();
         var userName = UserService.getUserName(moduleUserId);
         String title = context.getString(R.string.xposed_module_request_scope_title);
@@ -313,21 +375,21 @@ public class LSPNotificationManager {
                 .setAutoCancel(true)
                 .setTimeoutAfter(1000 * 60 * 60)
                 .setStyle(style)
-                .setDeleteIntent(getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "delete", callback))
+                .setDeleteIntent(getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "delete", callback, api101))
                 .setActions(new Notification.Action.Builder(
                                 Icon.createWithResource(context, R.drawable.ic_baseline_check_24),
                                 context.getString(R.string.scope_approve),
-                                getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "approve", callback))
+                                getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "approve", callback, api101))
                                 .build(),
                         new Notification.Action.Builder(
                                 Icon.createWithResource(context, R.drawable.ic_baseline_close_24),
                                 context.getString(R.string.scope_deny),
-                                getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "deny", callback))
+                                getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "deny", callback, api101))
                                 .build(),
                         new Notification.Action.Builder(
                                 Icon.createWithResource(context, R.drawable.ic_baseline_block_24),
                                 context.getString(R.string.nerver_ask_again),
-                                getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "block", callback))
+                                getModuleScopeIntent(modulePackageName, moduleUserId, scopePackageName, "block", callback, api101))
                                 .build()
                 ).build();
         notification.extras.putString("android.substName", "LSPosed");
@@ -338,7 +400,7 @@ public class LSPNotificationManager {
                     notification, 0);
         } catch (RemoteException e) {
             try {
-                callback.onScopeRequestFailed(scopePackageName, e.getMessage());
+                notifyScopeRequestFailed(callback, api101, scopePackageName, e.getMessage());
             } catch (RemoteException ignored) {
             }
             Log.e(TAG, "request module scope", e);

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPNotificationManager.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPNotificationManager.java
@@ -248,9 +248,10 @@ public class LSPNotificationManager {
     private static final String SCOPE_CALLBACK_DESCRIPTOR = "io.github.libxposed.service.IXposedScopeCallback";
     // API 101 IXposedScopeCallback transaction codes. these collide with the API 100
     // ones, so we can't just call the interface directly (see notifyScopeRequest* below):
-    //   1 = onScopeRequestApproved(List<String>), 2 = onScopeRequestFailed(String)
-    private static final int SCOPE_CALLBACK_APPROVED_TRANSACTION = 1;
-    private static final int SCOPE_CALLBACK_FAILED_TRANSACTION = 2;
+    //   2 = onScopeRequestApproved(List<String>), 3 = onScopeRequestFailed(String)
+    // (AIDL-declared 1/2, +1 like every IXposedService code)
+    private static final int SCOPE_CALLBACK_APPROVED_TRANSACTION = 2;
+    private static final int SCOPE_CALLBACK_FAILED_TRANSACTION = 3;
 
     // deliver scope results on the wire the module was built with. API 100 modules get
     // per-package callbacks (approved/denied/timeout/failed with a package name),

--- a/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
+++ b/daemon/src/main/java/org/lsposed/lspd/service/LSPosedService.java
@@ -297,30 +297,33 @@ public class LSPosedService extends ILSPosedService.Stub {
         var action = data.getQueryParameter("action");
         if (action == null) return;
 
+        // does the requesting module speak API 101? the flag rides in the notification
+        // intent, set by LSPNotificationManager#getModuleScopeIntent when it's shown.
+        var api101 = extras.getBoolean("api101", false);
         var iCallback = IXposedScopeCallback.Stub.asInterface(callback);
         try {
             var applicationInfo = PackageService.getApplicationInfo(scopePackageName, 0, userId);
             if (applicationInfo == null) {
-                iCallback.onScopeRequestFailed(scopePackageName, "Package not found");
+                LSPNotificationManager.notifyScopeRequestFailed(iCallback, api101, scopePackageName, "Package not found");
                 return;
             }
 
             switch (action) {
                 case "approve" -> {
                     ConfigManager.getInstance().setModuleScope(packageName, scopePackageName, userId);
-                    iCallback.onScopeRequestApproved(scopePackageName);
+                    LSPNotificationManager.notifyScopeRequestApproved(iCallback, api101, scopePackageName);
                 }
-                case "deny" -> iCallback.onScopeRequestDenied(scopePackageName);
-                case "delete" -> iCallback.onScopeRequestTimeout(scopePackageName);
+                case "deny" -> LSPNotificationManager.notifyScopeRequestDenied(iCallback, api101, scopePackageName, "User rejected");
+                case "delete" -> LSPNotificationManager.notifyScopeRequestTimeout(iCallback, api101, scopePackageName, "Timeout");
                 case "block" -> {
                     ConfigManager.getInstance().blockScopeRequest(packageName);
-                    iCallback.onScopeRequestDenied(scopePackageName);
+                    LSPNotificationManager.notifyScopeRequestDenied(iCallback, api101, scopePackageName, "Blocked by user");
                 }
             }
             Log.i(TAG, action + " scope " + scopePackageName + " for " + packageName + " in user " + userId);
         } catch (RemoteException e) {
             try {
-                iCallback.onScopeRequestFailed(scopePackageName, e.getMessage());
+                LSPNotificationManager.notifyScopeRequestFailed(iCallback, api101, scopePackageName, e.getMessage());
             } catch (RemoteException ignored) {
                 // callback died
             }

--- a/libxposed/api/build.gradle.kts
+++ b/libxposed/api/build.gradle.kts
@@ -8,7 +8,9 @@ android {
     sourceSets {
         val main by getting
         main.apply {
-            setRoot("api/api/src/main")
+            // Vendored superset of the libxposed API 100 + 101 surfaces. The upstream
+            // submodule (api/api) is kept purely as a reference and is no longer compiled.
+            setRoot("src/main")
         }
     }
 

--- a/libxposed/api/src/main/AndroidManifest.xml
+++ b/libxposed/api/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/libxposed/api/src/main/java/io/github/libxposed/api/XposedInterface.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/XposedInterface.java
@@ -1,0 +1,652 @@
+package io.github.libxposed.api;
+
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.os.ParcelFileDescriptor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import io.github.libxposed.api.utils.DexParser;
+
+/**
+ * Xposed interface for modules to operate on application processes.
+ *
+ * <p>This is a superset of the libxposed API 100 and API 101 surfaces. Modules compiled
+ * against either published version run against this interface: the members of both APIs
+ * are present here, and the framework dispatches each call to the matching engine
+ * automatically (overloads resolve to the API 100 or API 101 code path at the call site).
+ * </p>
+ */
+@SuppressWarnings("unused")
+public interface XposedInterface {
+
+    // ------------------------------------------------------------------
+    // API 100 surface
+    // ------------------------------------------------------------------
+
+    /**
+     * The SDK API version of the libxposed 100 surface.
+     */
+    int API = 100;
+
+    /**
+     * Indicates that the framework is running as root.
+     */
+    int FRAMEWORK_PRIVILEGE_ROOT = 0;
+
+    /**
+     * Indicates that the framework is running in a container with a fake system_server.
+     */
+    int FRAMEWORK_PRIVILEGE_CONTAINER = 1;
+
+    /**
+     * Indicates that the framework is running as a different app, which may have at most shell permission.
+     */
+    int FRAMEWORK_PRIVILEGE_APP = 2;
+
+    /**
+     * Indicates that the framework is embedded in the hooked app,
+     * which means {@link #getRemotePreferences} will be null and remote file is unsupported.
+     */
+    int FRAMEWORK_PRIVILEGE_EMBEDDED = 3;
+
+    // ------------------------------------------------------------------
+    // API 101 surface
+    // ------------------------------------------------------------------
+
+    /**
+     * The API version of the libxposed 101 surface.
+     */
+    int API_101 = 101;
+
+    /**
+     * The API version of this <b>library</b>. Modules should use {@link #getApiVersion()}
+     * to check the API version at runtime.
+     */
+    int LIB_API = API_101;
+
+    /**
+     * The framework has the capability to hook system_server and other system processes.
+     */
+    long PROP_CAP_SYSTEM = 1L;
+
+    /**
+     * The framework provides remote preferences and remote files support.
+     */
+    long PROP_CAP_REMOTE = 1L << 1;
+
+    /**
+     * The framework disallows accessing Xposed API via reflection or dynamically loaded code.
+     */
+    long PROP_RT_API_PROTECTION = 1L << 2;
+
+    // ------------------------------------------------------------------
+    // Shared constants
+    // ------------------------------------------------------------------
+
+    /**
+     * The default hook priority.
+     */
+    int PRIORITY_DEFAULT = 50;
+
+    /**
+     * Execute at the end of the interception chain.
+     */
+    int PRIORITY_LOWEST = Integer.MIN_VALUE;
+
+    /**
+     * Execute at the beginning of the interception chain.
+     */
+    int PRIORITY_HIGHEST = Integer.MAX_VALUE;
+
+    // ------------------------------------------------------------------
+    // API 100: before / after hook callbacks
+    // ------------------------------------------------------------------
+
+    /**
+     * Contextual interface for before invocation callbacks.
+     */
+    interface BeforeHookCallback {
+        /**
+         * Gets the method / constructor to be hooked.
+         */
+        @NonNull
+        Member getMember();
+
+        /**
+         * Gets the {@code this} object, or {@code null} if the method is static.
+         */
+        @Nullable
+        Object getThisObject();
+
+        /**
+         * Gets the arguments passed to the method / constructor. You can modify the arguments.
+         */
+        @NonNull
+        Object[] getArgs();
+
+        /**
+         * Sets the return value of the method and skip the invocation.
+         */
+        void returnAndSkip(@Nullable Object result);
+
+        /**
+         * Throw an exception from the method / constructor and skip the invocation.
+         */
+        void throwAndSkip(@Nullable Throwable throwable);
+    }
+
+    /**
+     * Contextual interface for after invocation callbacks.
+     */
+    interface AfterHookCallback {
+        /**
+         * Gets the method / constructor to be hooked.
+         */
+        @NonNull
+        Member getMember();
+
+        /**
+         * Gets the {@code this} object, or {@code null} if the method is static.
+         */
+        @Nullable
+        Object getThisObject();
+
+        /**
+         * Gets all arguments passed to the method / constructor.
+         */
+        @NonNull
+        Object[] getArgs();
+
+        /**
+         * Gets the return value of the method or the before invocation callback.
+         */
+        @Nullable
+        Object getResult();
+
+        /**
+         * Gets the exception thrown by the method / constructor or the before invocation callback.
+         */
+        @Nullable
+        Throwable getThrowable();
+
+        /**
+         * Gets whether the invocation was skipped by the before invocation callback.
+         */
+        boolean isSkipped();
+
+        /**
+         * Sets the return value of the method and skip the invocation.
+         */
+        void setResult(@Nullable Object result);
+
+        /**
+         * Sets the exception thrown by the method / constructor.
+         */
+        void setThrowable(@Nullable Throwable throwable);
+    }
+
+    /**
+     * Handle for canceling a hook (API 100).
+     *
+     * @param <T> {@link Method} or {@link Constructor}
+     */
+    interface MethodUnhooker<T> {
+        /**
+         * Gets the method or constructor being hooked.
+         */
+        @NonNull
+        T getOrigin();
+
+        /**
+         * Cancels the hook.
+         */
+        void unhook();
+    }
+
+    // ------------------------------------------------------------------
+    // API 101 hook model
+    // ------------------------------------------------------------------
+
+    /**
+     * Invoker for a method or constructor. Invocations through invokers will bypass access checks.
+     */
+    interface Invoker<T extends Invoker<T, U>, U extends Executable> {
+        /**
+         * Type of the invoker, which determines the hook chain to be invoked.
+         */
+        sealed interface Type permits Type.Origin, Type.Chain {
+            /**
+             * A convenience constant for {@link Origin}.
+             */
+            Origin ORIGIN = new Origin();
+
+            /**
+             * Invokes the original executable, skipping all hooks.
+             */
+            record Origin() implements Type {
+            }
+
+            /**
+             * Invokes the executable starting from the middle of the hook chain, skipping all
+             * hooks with priority higher than the given value.
+             */
+            record Chain(int maxPriority) implements Type {
+                /**
+                 * Invoking the executable with full hook chain.
+                 */
+                public static final Chain FULL = new Chain(PRIORITY_HIGHEST);
+            }
+        }
+
+        /**
+         * Sets the type of the invoker, which determines the hook chain to be invoked.
+         */
+        T setType(@NonNull Type type);
+
+        /**
+         * Invokes the method (or the constructor as a method) through the hook chain determined by
+         * the invoker's type.
+         */
+        Object invoke(Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException;
+
+        /**
+         * Invokes the special (non-virtual) method (or the constructor as a method) on a given
+         * object instance, bypassing overridden methods in subclasses.
+         */
+        Object invokeSpecial(@NonNull Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException;
+    }
+
+    /**
+     * Invoker for a constructor.
+     */
+    interface CtorInvoker<T> extends Invoker<CtorInvoker<T>, Constructor<T>> {
+        /**
+         * Creates a new instance through the hook chain determined by the invoker's type.
+         */
+        @NonNull
+        T newInstance(Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException;
+
+        /**
+         * Creates a new instance of the given subclass, but initializes it with a parent constructor.
+         */
+        @NonNull
+        <U> U newInstanceSpecial(@NonNull Class<U> subClass, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException;
+    }
+
+    /**
+     * Interceptor chain for a method or constructor. Chain objects cannot be shared among threads or
+     * reused after {@link Hooker#intercept(Chain)} ends.
+     */
+    interface Chain {
+        /**
+         * Gets the method / constructor being hooked.
+         */
+        @NonNull
+        Executable getExecutable();
+
+        /**
+         * Gets the {@code this} pointer for the call, or {@code null} for static methods.
+         */
+        Object getThisObject();
+
+        /**
+         * Gets the arguments. The returned list is immutable.
+         */
+        @NonNull
+        List<Object> getArgs();
+
+        /**
+         * Gets the argument at the given index.
+         */
+        Object getArg(int index) throws IndexOutOfBoundsException, ClassCastException;
+
+        /**
+         * Proceeds to the next interceptor in the chain with the same arguments and {@code this} pointer.
+         */
+        Object proceed() throws Throwable;
+
+        /**
+         * Proceeds to the next interceptor in the chain with the given arguments.
+         */
+        Object proceed(@NonNull Object[] args) throws Throwable;
+
+        /**
+         * Proceeds to the next interceptor in the chain with the same arguments and given {@code this} pointer.
+         */
+        Object proceedWith(@NonNull Object thisObject) throws Throwable;
+
+        /**
+         * Proceeds to the next interceptor in the chain with the given arguments and {@code this} pointer.
+         */
+        Object proceedWith(@NonNull Object thisObject, @NonNull Object[] args) throws Throwable;
+    }
+
+    /**
+     * Hooker for a method or constructor.
+     *
+     * <p>Modules targeting API 101 implement {@link #intercept(Chain)}. Modules targeting API 100
+     * instead provide public static {@code before} / {@code after} methods; the framework keeps
+     * dispatching those through the API 100 path, so the {@code intercept} default below is never
+     * invoked for them.</p>
+     */
+    interface Hooker {
+        /**
+         * Intercepts a method / constructor call.
+         *
+         * @param chain The interceptor chain for the call
+         * @return The result to be returned from the interceptor
+         * @throws Throwable Throw any exception from the interceptor
+         */
+        default Object intercept(@NonNull Chain chain) throws Throwable {
+            throw new AbstractMethodError("Hooker does not implement intercept");
+        }
+    }
+
+    /**
+     * Handle for a hook (API 101).
+     */
+    interface HookHandle {
+        /**
+         * Gets the method / constructor being hooked.
+         */
+        @NonNull
+        Executable getExecutable();
+
+        /**
+         * Cancels the hook. This method is idempotent.
+         */
+        void unhook();
+    }
+
+    /**
+     * Exception handling mode for hookers (API 101).
+     */
+    enum ExceptionMode {
+        /**
+         * Follows the global exception mode configured in {@code module.prop}. Defaults to {@link #PROTECTIVE}
+         * if not specified.
+         */
+        DEFAULT,
+        /**
+         * Any exception thrown by the <b>hooker</b> will be caught and logged, and the call will proceed as
+         * if no hook exists.
+         */
+        PROTECTIVE,
+        /**
+         * Any exception thrown by the hooker will be propagated to the caller as usual.
+         */
+        PASSTHROUGH,
+    }
+
+    /**
+     * Builder for configuring a hook (API 101).
+     */
+    interface HookBuilder {
+        /**
+         * Sets the priority of the hook.
+         */
+        HookBuilder setPriority(int priority);
+
+        /**
+         * Sets the exception handling mode for the hook.
+         */
+        HookBuilder setExceptionMode(@NonNull ExceptionMode mode);
+
+        /**
+         * Sets the hooker for the method / constructor and builds the hook.
+         */
+        @NonNull
+        HookHandle intercept(@NonNull Hooker hooker);
+    }
+
+    // ------------------------------------------------------------------
+    // Framework details
+    // ------------------------------------------------------------------
+
+    /**
+     * Gets the runtime Xposed API version. Framework implementations must <b>not</b> override this method.
+     */
+    default int getApiVersion() {
+        return LIB_API;
+    }
+
+    /**
+     * Gets the Xposed framework name of current implementation.
+     */
+    @NonNull
+    String getFrameworkName();
+
+    /**
+     * Gets the Xposed framework version of current implementation.
+     */
+    @NonNull
+    String getFrameworkVersion();
+
+    /**
+     * Gets the Xposed framework version code of current implementation.
+     */
+    long getFrameworkVersionCode();
+
+    /**
+     * Gets the Xposed framework properties (API 101).
+     * Properties with prefix {@code PROP_RT_} may change among launches.
+     */
+    long getFrameworkProperties();
+
+    /**
+     * Gets the Xposed framework privilege of current implementation (API 100).
+     */
+    int getFrameworkPrivilege();
+
+    // ------------------------------------------------------------------
+    // Hooking (API 101)
+    // ------------------------------------------------------------------
+
+    /**
+     * Hook a method / constructor (API 101).
+     *
+     * @param origin The executable to be hooked
+     * @return The builder for the hook
+     */
+    @NonNull
+    HookBuilder hook(@NonNull Executable origin);
+
+    /**
+     * Hook the static initializer of a class (API 101).
+     *
+     * @param origin The class whose static initializer is to be hooked
+     * @return The builder for the hook
+     */
+    @NonNull
+    HookBuilder hookClassInitializer(@NonNull Class<?> origin);
+
+    /**
+     * Deoptimizes a method / constructor in case hooked callee is not called because of inline (API 101).
+     */
+    boolean deoptimize(@NonNull Executable executable);
+
+    /**
+     * Get a method invoker for the given method (API 101).
+     */
+    @NonNull
+    Invoker<?, Method> getInvoker(@NonNull Method method);
+
+    /**
+     * Get a constructor invoker for the given constructor (API 101).
+     */
+    @NonNull
+    <T> CtorInvoker<T> getInvoker(@NonNull Constructor<T> constructor);
+
+    // ------------------------------------------------------------------
+    // Hooking (API 100)
+    // ------------------------------------------------------------------
+
+    /**
+     * Hook a method with default priority (API 100).
+     */
+    @NonNull
+    MethodUnhooker<Method> hook(@NonNull Method origin, @NonNull Class<? extends Hooker> hooker);
+
+    /**
+     * Hook a method with specified priority (API 100).
+     */
+    @NonNull
+    MethodUnhooker<Method> hook(@NonNull Method origin, int priority, @NonNull Class<? extends Hooker> hooker);
+
+    /**
+     * Hook a constructor with default priority (API 100).
+     */
+    @NonNull
+    <T> MethodUnhooker<Constructor<T>> hook(@NonNull Constructor<T> origin, @NonNull Class<? extends Hooker> hooker);
+
+    /**
+     * Hook a constructor with specified priority (API 100).
+     */
+    @NonNull
+    <T> MethodUnhooker<Constructor<T>> hook(@NonNull Constructor<T> origin, int priority, @NonNull Class<? extends Hooker> hooker);
+
+    /**
+     * Hook the static initializer of a class with default priority (API 100).
+     */
+    @NonNull
+    <T> MethodUnhooker<Constructor<T>> hookClassInitializer(@NonNull Class<T> origin, @NonNull Class<? extends Hooker> hooker);
+
+    /**
+     * Hook the static initializer of a class with specified priority (API 100).
+     */
+    @NonNull
+    <T> MethodUnhooker<Constructor<T>> hookClassInitializer(@NonNull Class<T> origin, int priority, @NonNull Class<? extends Hooker> hooker);
+
+    /**
+     * Deoptimize a method to avoid callee being inlined (API 100).
+     */
+    boolean deoptimize(@NonNull Method method);
+
+    /**
+     * Deoptimize a constructor to avoid callee being inlined (API 100).
+     */
+    <T> boolean deoptimize(@NonNull Constructor<T> constructor);
+
+    /**
+     * Basically the same as {@link Method#invoke}, but calls the original method
+     * as it was before the interception by Xposed (API 100).
+     */
+    @Nullable
+    Object invokeOrigin(@NonNull Method method, @Nullable Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException;
+
+    /**
+     * Basically the same as {@link Constructor#newInstance}, but calls the original constructor
+     * as it was before the interception by Xposed (API 100).
+     */
+    <T> void invokeOrigin(@NonNull Constructor<T> constructor, @NonNull T thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException;
+
+    /**
+     * Invokes a special (non-virtual) method on a given object instance (API 100).
+     */
+    @Nullable
+    Object invokeSpecial(@NonNull Method method, @NonNull Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException;
+
+    /**
+     * Invokes a special (non-virtual) constructor on a given object instance (API 100).
+     */
+    <T> void invokeSpecial(@NonNull Constructor<T> constructor, @NonNull T thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException;
+
+    /**
+     * Basically the same as {@link Constructor#newInstance}, but calls the original constructor
+     * as it was before the interception by Xposed (API 100).
+     */
+    @NonNull
+    <T> T newInstanceOrigin(@NonNull Constructor<T> constructor, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException;
+
+    /**
+     * Creates a new instance of the given subclass, but initialize it with a parent constructor (API 100).
+     */
+    @NonNull
+    <T, U> U newInstanceSpecial(@NonNull Constructor<T> constructor, @NonNull Class<U> subClass, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException;
+
+    // ------------------------------------------------------------------
+    // Logging
+    // ------------------------------------------------------------------
+
+    /**
+     * Writes a message to the Xposed log (API 101).
+     */
+    void log(int priority, @Nullable String tag, @NonNull String msg);
+
+    /**
+     * Writes a message to the Xposed log.
+     */
+    void log(int priority, @Nullable String tag, @NonNull String msg, @Nullable Throwable tr);
+
+    /**
+     * Writes a message to the Xposed log (API 100).
+     *
+     * @deprecated Use {@link #log(int, String, String, Throwable)} instead.
+     */
+    @Deprecated
+    void log(@NonNull String message);
+
+    /**
+     * Writes a message with a stack trace to the Xposed log (API 100).
+     *
+     * @deprecated Use {@link #log(int, String, String, Throwable)} instead.
+     */
+    @Deprecated
+    void log(@NonNull String message, @NonNull Throwable throwable);
+
+    // ------------------------------------------------------------------
+    // Module info
+    // ------------------------------------------------------------------
+
+    /**
+     * Gets the application info of the module (API 101).
+     */
+    @NonNull
+    ApplicationInfo getModuleApplicationInfo();
+
+    /**
+     * Gets the application info of the module (API 100).
+     */
+    @NonNull
+    ApplicationInfo getApplicationInfo();
+
+    /**
+     * Parse a dex file in memory (API 100).
+     */
+    @Nullable
+    DexParser parseDex(@NonNull ByteBuffer dexData, boolean includeAnnotations) throws IOException;
+
+    // ------------------------------------------------------------------
+    // Remote data
+    // ------------------------------------------------------------------
+
+    /**
+     * Gets remote preferences stored in Xposed framework. Note that those are read-only in hooked apps.
+     */
+    @NonNull
+    SharedPreferences getRemotePreferences(@NonNull String group);
+
+    /**
+     * List all files in the module's shared data directory.
+     */
+    @NonNull
+    String[] listRemoteFiles();
+
+    /**
+     * Open a file in the module's shared data directory. The file is opened in read-only mode.
+     */
+    @NonNull
+    ParcelFileDescriptor openRemoteFile(@NonNull String name) throws FileNotFoundException;
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/XposedInterfaceWrapper.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/XposedInterfaceWrapper.java
@@ -1,0 +1,307 @@
+package io.github.libxposed.api;
+
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.os.ParcelFileDescriptor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+import io.github.libxposed.api.utils.DexParser;
+
+/**
+ * Wrapper of {@link XposedInterface} used by modules to shield framework implementation details.
+ *
+ * <p>Superset of the API 100 and API 101 wrappers: the base interface can be supplied either
+ * through the package-private constructor (API 100) or through {@link #attachFramework(XposedInterface)}
+ * (API 101).</p>
+ */
+public class XposedInterfaceWrapper implements XposedInterface {
+
+    private volatile XposedInterface mBase;
+
+    /**
+     * Instantiates a wrapper without a base (API 101 style); the framework will attach the base
+     * through {@link #attachFramework(XposedInterface)}.
+     */
+    public XposedInterfaceWrapper() {
+    }
+
+    /**
+     * Instantiates a wrapper with a base (API 100 style).
+     */
+    XposedInterfaceWrapper(@NonNull XposedInterface base) {
+        mBase = base;
+    }
+
+    /**
+     * Attaches the framework interface to the module. Modules should never call this method.
+     *
+     * @param base The framework interface
+     */
+    @SuppressWarnings("unused")
+    public final void attachFramework(@NonNull XposedInterface base) {
+        if (mBase != null) {
+            throw new IllegalStateException("Framework already attached");
+        }
+        mBase = base;
+    }
+
+    private void ensureAttached() {
+        if (mBase == null) {
+            throw new IllegalStateException("Framework not attached");
+        }
+    }
+
+    @Override
+    public final int getApiVersion() {
+        ensureAttached();
+        return XposedInterface.super.getApiVersion();
+    }
+
+    @NonNull
+    @Override
+    public final String getFrameworkName() {
+        ensureAttached();
+        return mBase.getFrameworkName();
+    }
+
+    @NonNull
+    @Override
+    public final String getFrameworkVersion() {
+        ensureAttached();
+        return mBase.getFrameworkVersion();
+    }
+
+    @Override
+    public final long getFrameworkVersionCode() {
+        ensureAttached();
+        return mBase.getFrameworkVersionCode();
+    }
+
+    @Override
+    public final long getFrameworkProperties() {
+        ensureAttached();
+        return mBase.getFrameworkProperties();
+    }
+
+    @Override
+    public final int getFrameworkPrivilege() {
+        ensureAttached();
+        return mBase.getFrameworkPrivilege();
+    }
+
+    // API 101 hooking
+
+    @NonNull
+    @Override
+    public final HookBuilder hook(@NonNull Executable origin) {
+        ensureAttached();
+        return mBase.hook(origin);
+    }
+
+    @NonNull
+    @Override
+    public final HookBuilder hookClassInitializer(@NonNull Class<?> origin) {
+        ensureAttached();
+        return mBase.hookClassInitializer(origin);
+    }
+
+    @Override
+    public final boolean deoptimize(@NonNull Executable executable) {
+        ensureAttached();
+        return mBase.deoptimize(executable);
+    }
+
+    @NonNull
+    @Override
+    public final Invoker<?, Method> getInvoker(@NonNull Method method) {
+        ensureAttached();
+        return mBase.getInvoker(method);
+    }
+
+    @NonNull
+    @Override
+    public final <T> CtorInvoker<T> getInvoker(@NonNull Constructor<T> constructor) {
+        ensureAttached();
+        return mBase.getInvoker(constructor);
+    }
+
+    // API 100 hooking
+
+    @NonNull
+    @Override
+    public final MethodUnhooker<Method> hook(@NonNull Method origin, @NonNull Class<? extends Hooker> hooker) {
+        ensureAttached();
+        return mBase.hook(origin, hooker);
+    }
+
+    @NonNull
+    @Override
+    public final MethodUnhooker<Method> hook(@NonNull Method origin, int priority, @NonNull Class<? extends Hooker> hooker) {
+        ensureAttached();
+        return mBase.hook(origin, priority, hooker);
+    }
+
+    @NonNull
+    @Override
+    public final <T> MethodUnhooker<Constructor<T>> hook(@NonNull Constructor<T> origin, @NonNull Class<? extends Hooker> hooker) {
+        ensureAttached();
+        return mBase.hook(origin, hooker);
+    }
+
+    @NonNull
+    @Override
+    public final <T> MethodUnhooker<Constructor<T>> hook(@NonNull Constructor<T> origin, int priority, @NonNull Class<? extends Hooker> hooker) {
+        ensureAttached();
+        return mBase.hook(origin, priority, hooker);
+    }
+
+    @NonNull
+    @Override
+    public final <T> MethodUnhooker<Constructor<T>> hookClassInitializer(@NonNull Class<T> origin, @NonNull Class<? extends Hooker> hooker) {
+        ensureAttached();
+        return mBase.hookClassInitializer(origin, hooker);
+    }
+
+    @NonNull
+    @Override
+    public final <T> MethodUnhooker<Constructor<T>> hookClassInitializer(@NonNull Class<T> origin, int priority, @NonNull Class<? extends Hooker> hooker) {
+        ensureAttached();
+        return mBase.hookClassInitializer(origin, priority, hooker);
+    }
+
+    @Override
+    public final boolean deoptimize(@NonNull Method method) {
+        ensureAttached();
+        return mBase.deoptimize(method);
+    }
+
+    @Override
+    public final <T> boolean deoptimize(@NonNull Constructor<T> constructor) {
+        ensureAttached();
+        return mBase.deoptimize(constructor);
+    }
+
+    @Nullable
+    @Override
+    public final Object invokeOrigin(@NonNull Method method, @Nullable Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException {
+        ensureAttached();
+        return mBase.invokeOrigin(method, thisObject, args);
+    }
+
+    @Override
+    public final <T> void invokeOrigin(@NonNull Constructor<T> constructor, @NonNull T thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException {
+        ensureAttached();
+        mBase.invokeOrigin(constructor, thisObject, args);
+    }
+
+    @Nullable
+    @Override
+    public final Object invokeSpecial(@NonNull Method method, @NonNull Object thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException {
+        ensureAttached();
+        return mBase.invokeSpecial(method, thisObject, args);
+    }
+
+    @Override
+    public final <T> void invokeSpecial(@NonNull Constructor<T> constructor, @NonNull T thisObject, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException {
+        ensureAttached();
+        mBase.invokeSpecial(constructor, thisObject, args);
+    }
+
+    @NonNull
+    @Override
+    public final <T> T newInstanceOrigin(@NonNull Constructor<T> constructor, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException {
+        ensureAttached();
+        return mBase.newInstanceOrigin(constructor, args);
+    }
+
+    @NonNull
+    @Override
+    public final <T, U> U newInstanceSpecial(@NonNull Constructor<T> constructor, @NonNull Class<U> subClass, Object... args) throws InvocationTargetException, IllegalArgumentException, IllegalAccessException, InstantiationException {
+        ensureAttached();
+        return mBase.newInstanceSpecial(constructor, subClass, args);
+    }
+
+    // Logging
+
+    @Override
+    public final void log(int priority, @Nullable String tag, @NonNull String msg) {
+        ensureAttached();
+        mBase.log(priority, tag, msg);
+    }
+
+    @Override
+    public final void log(int priority, @Nullable String tag, @NonNull String msg, @Nullable Throwable tr) {
+        ensureAttached();
+        mBase.log(priority, tag, msg, tr);
+    }
+
+    @Deprecated
+    @Override
+    public final void log(@NonNull String message) {
+        ensureAttached();
+        mBase.log(message);
+    }
+
+    @Deprecated
+    @Override
+    public final void log(@NonNull String message, @NonNull Throwable throwable) {
+        ensureAttached();
+        mBase.log(message, throwable);
+    }
+
+    // Module info
+
+    @NonNull
+    @Override
+    public final ApplicationInfo getModuleApplicationInfo() {
+        ensureAttached();
+        return mBase.getModuleApplicationInfo();
+    }
+
+    @NonNull
+    @Override
+    public final ApplicationInfo getApplicationInfo() {
+        ensureAttached();
+        return mBase.getApplicationInfo();
+    }
+
+    @Nullable
+    @Override
+    public final DexParser parseDex(@NonNull ByteBuffer dexData, boolean includeAnnotations) throws IOException {
+        ensureAttached();
+        return mBase.parseDex(dexData, includeAnnotations);
+    }
+
+    // Remote data
+
+    @NonNull
+    @Override
+    public final SharedPreferences getRemotePreferences(@NonNull String name) {
+        ensureAttached();
+        return mBase.getRemotePreferences(name);
+    }
+
+    @NonNull
+    @Override
+    public final String[] listRemoteFiles() {
+        ensureAttached();
+        return mBase.listRemoteFiles();
+    }
+
+    @NonNull
+    @Override
+    public final ParcelFileDescriptor openRemoteFile(@NonNull String name) throws FileNotFoundException {
+        ensureAttached();
+        return mBase.openRemoteFile(name);
+    }
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/XposedModule.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/XposedModule.java
@@ -1,0 +1,39 @@
+package io.github.libxposed.api;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Super class which all Xposed module entry classes should extend.<br/>
+ * Entry classes will be instantiated exactly once for each process.
+ *
+ * <p>Superset of the API 100 and API 101 entry points:</p>
+ * <ul>
+ * <li>Modules targeting API 100 declare a constructor taking
+ * {@code (XposedInterface, ModuleLoadedParam)}; the framework instantiates them through it.</li>
+ * <li>Modules targeting API 101 rely on the no-arg constructor; the framework attaches the
+ * framework interface through {@link XposedInterfaceWrapper#attachFramework(XposedInterface)}
+ * and then invokes {@link XposedModuleInterface#onModuleLoaded(ModuleLoadedParam)}.</li>
+ * </ul>
+ */
+@SuppressWarnings("unused")
+public abstract class XposedModule extends XposedInterfaceWrapper implements XposedModuleInterface {
+
+    /**
+     * Instantiates a new Xposed module (API 100 style).<br/>
+     * When the module is loaded into the target process, this constructor will be called.
+     *
+     * @param base  The implementation interface provided by the framework, should not be used by the module
+     * @param param Information about the process in which the module is loaded
+     */
+    public XposedModule(@NonNull XposedInterface base, @NonNull ModuleLoadedParam param) {
+        super(base);
+    }
+
+    /**
+     * Instantiates a new Xposed module (API 101 style).<br/>
+     * The framework calls {@link #attachFramework(XposedInterface)} and then
+     * {@link XposedModuleInterface#onModuleLoaded(ModuleLoadedParam)} after construction.
+     */
+    public XposedModule() {
+    }
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/XposedModuleInterface.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/XposedModuleInterface.java
@@ -1,0 +1,147 @@
+package io.github.libxposed.api;
+
+import android.app.AppComponentFactory;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+/**
+ * Interface for module initialization.
+ *
+ * <p>Superset of the API 100 and API 101 lifecycle surfaces. Modules compiled against either
+ * version override the callbacks they know; the framework invokes every callback and modules
+ * that do not override a given callback simply receive the default no-op.</p>
+ */
+@SuppressWarnings("unused")
+public interface XposedModuleInterface {
+
+    /**
+     * Wraps information about the process in which the module is loaded.
+     * This information only indicates the state at the time of loading and will not be updated.
+     */
+    interface ModuleLoadedParam {
+        /**
+         * Returns whether the current process is system server.
+         */
+        boolean isSystemServer();
+
+        /**
+         * Gets the process name.
+         */
+        @NonNull
+        String getProcessName();
+    }
+
+    /**
+     * Wraps information about the package being loaded.
+     * <p>
+     * Note that API 100 exposed {@link #getClassLoader()} directly on this interface; API 101 moved
+     * it to {@link PackageReadyParam}. The superset keeps both accessors so that modules of either
+     * generation can read the classloader they expect.
+     * </p>
+     */
+    interface PackageLoadedParam {
+        /**
+         * Gets the package name of the current package.
+         */
+        @NonNull
+        String getPackageName();
+
+        /**
+         * Gets the {@link ApplicationInfo} of the current package.
+         */
+        @NonNull
+        ApplicationInfo getApplicationInfo();
+
+        /**
+         * Returns whether this is the first and main package loaded in the process.
+         */
+        boolean isFirstPackage();
+
+        /**
+         * Gets the default classloader of the current package. This is the classloader that loads
+         * the package's code, resources and custom {@link AppComponentFactory}.
+         */
+        @RequiresApi(Build.VERSION_CODES.Q)
+        @NonNull
+        ClassLoader getDefaultClassLoader();
+
+        /**
+         * Gets the classloader of the package being loaded (API 100).
+         */
+        @NonNull
+        ClassLoader getClassLoader();
+    }
+
+    /**
+     * Wraps information about the package whose classloader is ready (API 101).
+     */
+    interface PackageReadyParam extends PackageLoadedParam {
+        /**
+         * Gets the {@link AppComponentFactory} of the current package.
+         */
+        @RequiresApi(Build.VERSION_CODES.P)
+        @NonNull
+        AppComponentFactory getAppComponentFactory();
+    }
+
+    /**
+     * Wraps information about system server (API 100).
+     */
+    interface SystemServerLoadedParam {
+        /**
+         * Gets the class loader of system server.
+         */
+        @NonNull
+        ClassLoader getClassLoader();
+    }
+
+    /**
+     * Wraps information about system server (API 101).
+     */
+    interface SystemServerStartingParam {
+        /**
+         * Gets the class loader of system server.
+         */
+        @NonNull
+        ClassLoader getClassLoader();
+    }
+
+    /**
+     * Gets notified when the module is loaded into the target process (API 101).<br/>
+     * This callback is guaranteed to be called exactly once for a process.
+     */
+    default void onModuleLoaded(@NonNull ModuleLoadedParam param) {
+    }
+
+    /**
+     * Gets notified when a {@link android.R.attr#hasCode} package is loaded into the process.
+     * This is the time when the default classloader is ready but before the instantiation of
+     * {@link AppComponentFactory}.
+     */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    default void onPackageLoaded(@NonNull PackageLoadedParam param) {
+    }
+
+    /**
+     * Gets notified when {@link AppComponentFactory} has instantiated the classloader
+     * and is ready to create {@link android.app.Application} (API 101).
+     */
+    default void onPackageReady(@NonNull PackageReadyParam param) {
+    }
+
+    /**
+     * Gets notified when the system server is loaded (API 100).
+     */
+    default void onSystemServerLoaded(@NonNull SystemServerLoadedParam param) {
+    }
+
+    /**
+     * Gets notified when system server is ready to start critical services (API 101).
+     */
+    default void onSystemServerStarting(@NonNull SystemServerStartingParam param) {
+    }
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/error/HookFailedError.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/error/HookFailedError.java
@@ -1,0 +1,24 @@
+package io.github.libxposed.api.error;
+
+/**
+ * Thrown to indicate that a hook failed due to framework internal error.
+ * <p>
+ * This inherits from {@link Error} rather than {@link RuntimeException} because hook failures are
+ * considered fatal framework bugs. Module developers <b>should not</b> attempt to catch this error
+ * to provide fallbacks.
+ * </p>
+ */
+@SuppressWarnings("unused")
+public class HookFailedError extends XposedFrameworkError {
+    public HookFailedError(String message) {
+        super(message);
+    }
+
+    public HookFailedError(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HookFailedError(Throwable cause) {
+        super(cause);
+    }
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/error/XposedFrameworkError.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/error/XposedFrameworkError.java
@@ -1,0 +1,18 @@
+package io.github.libxposed.api.error;
+
+/**
+ * Thrown to indicate that the Xposed framework function is broken.
+ */
+public class XposedFrameworkError extends Error {
+    public XposedFrameworkError(String message) {
+        super(message);
+    }
+
+    public XposedFrameworkError(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public XposedFrameworkError(Throwable cause) {
+        super(cause);
+    }
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/errors/HookFailedError.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/errors/HookFailedError.java
@@ -1,0 +1,19 @@
+package io.github.libxposed.api.errors;
+
+/**
+ * Thrown to indicate that a hook failed due to framework internal error.
+ */
+@SuppressWarnings("unused")
+public class HookFailedError extends XposedFrameworkError {
+    public HookFailedError(String message) {
+        super(message);
+    }
+
+    public HookFailedError(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HookFailedError(Throwable cause) {
+        super(cause);
+    }
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/errors/XposedFrameworkError.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/errors/XposedFrameworkError.java
@@ -1,0 +1,23 @@
+package io.github.libxposed.api.errors;
+
+/**
+ * Thrown to indicate that the Xposed framework function is broken.
+ *
+ * <p>This is the API 100 error. It extends the API 101 {@link io.github.libxposed.api.error.XposedFrameworkError}
+ * so that modules of either generation can catch the errors thrown by the framework's shared
+ * methods: API 100 modules catch {@code errors.XposedFrameworkError}, API 101 modules catch
+ * {@code error.XposedFrameworkError}, and both match.</p>
+ */
+public class XposedFrameworkError extends io.github.libxposed.api.error.XposedFrameworkError {
+    public XposedFrameworkError(String message) {
+        super(message);
+    }
+
+    public XposedFrameworkError(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public XposedFrameworkError(Throwable cause) {
+        super(cause);
+    }
+}

--- a/libxposed/api/src/main/java/io/github/libxposed/api/utils/DexParser.java
+++ b/libxposed/api/src/main/java/io/github/libxposed/api/utils/DexParser.java
@@ -1,0 +1,349 @@
+package io.github.libxposed.api.utils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.Closeable;
+
+/**
+ * Xposed interface for parsing dex files.
+ */
+@SuppressWarnings("unused")
+public interface DexParser extends Closeable {
+
+    /**
+     * The constant NO_INDEX.
+     */
+    int NO_INDEX = 0xffffffff;
+
+    /**
+     * The interface Array.
+     */
+    interface Array {
+        /**
+         * Get values value [].
+         *
+         * @return the value []
+         */
+        @NonNull
+        Value[] getValues();
+    }
+
+    /**
+     * The interface Annotation.
+     */
+    interface Annotation {
+        /**
+         * Gets visibility.
+         *
+         * @return the visibility
+         */
+        int getVisibility();
+
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
+        @NonNull
+        TypeId getType();
+
+        /**
+         * Get elements element [].
+         *
+         * @return the element []
+         */
+        @NonNull
+        Element[] getElements();
+    }
+
+    /**
+     * The interface Value.
+     */
+    interface Value {
+        /**
+         * Get value byte [].
+         *
+         * @return the byte []
+         */
+        @Nullable
+        byte[] getValue();
+
+        /**
+         * Gets value type.
+         *
+         * @return the value type
+         */
+        int getValueType();
+    }
+
+    /**
+     * The interface Element.
+     */
+    interface Element extends Value {
+        /**
+         * Gets name.
+         *
+         * @return the name
+         */
+        @NonNull
+        StringId getName();
+    }
+
+    /**
+     * The interface Id.
+     */
+    interface Id<Self> extends Comparable<Self> {
+        /**
+         * Gets id.
+         *
+         * @return the id
+         */
+        int getId();
+    }
+
+    /**
+     * The interface Type id.
+     */
+    interface TypeId extends Id<TypeId> {
+        /**
+         * Gets descriptor.
+         *
+         * @return the descriptor
+         */
+        @NonNull
+        StringId getDescriptor();
+    }
+
+    /**
+     * The interface String id.
+     */
+    interface StringId extends Id<StringId> {
+        /**
+         * Gets string.
+         *
+         * @return the string
+         */
+        @NonNull
+        String getString();
+    }
+
+    /**
+     * The interface Field id.
+     */
+    interface FieldId extends Id<FieldId> {
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
+        @NonNull
+        TypeId getType();
+
+        /**
+         * Gets declaring class.
+         *
+         * @return the declaring class
+         */
+        @NonNull
+        TypeId getDeclaringClass();
+
+        /**
+         * Gets name.
+         *
+         * @return the name
+         */
+        @NonNull
+        StringId getName();
+    }
+
+    /**
+     * The interface Method id.
+     */
+    interface MethodId extends Id<MethodId> {
+        /**
+         * Gets declaring class.
+         *
+         * @return the declaring class
+         */
+        @NonNull
+        TypeId getDeclaringClass();
+
+        /**
+         * Gets prototype.
+         *
+         * @return the prototype
+         */
+        @NonNull
+        ProtoId getPrototype();
+
+        /**
+         * Gets name.
+         *
+         * @return the name
+         */
+        @NonNull
+        StringId getName();
+    }
+
+    /**
+     * The interface Proto id.
+     */
+    interface ProtoId extends Id<ProtoId> {
+        /**
+         * Gets shorty.
+         *
+         * @return the shorty
+         */
+        @NonNull
+        StringId getShorty();
+
+        /**
+         * Gets return type.
+         *
+         * @return the return type
+         */
+        @NonNull
+        TypeId getReturnType();
+
+        /**
+         * Get parameters type id [].
+         *
+         * @return the type id []
+         */
+        @Nullable
+        TypeId[] getParameters();
+    }
+
+    /**
+     * Get string id string id [].
+     *
+     * @return the string id []
+     */
+    @NonNull
+    StringId[] getStringId();
+
+    /**
+     * Get type id type id [].
+     *
+     * @return the type id []
+     */
+    @NonNull
+    TypeId[] getTypeId();
+
+    /**
+     * Get field id field id [].
+     *
+     * @return the field id []
+     */
+    @NonNull
+    FieldId[] getFieldId();
+
+    /**
+     * Get method id method id [].
+     *
+     * @return the method id []
+     */
+    @NonNull
+    MethodId[] getMethodId();
+
+    /**
+     * Get proto id proto id [].
+     *
+     * @return the proto id []
+     */
+    @NonNull
+    ProtoId[] getProtoId();
+
+    /**
+     * Get annotations annotation [].
+     *
+     * @return the annotation []
+     */
+    @NonNull
+    Annotation[] getAnnotations();
+
+    /**
+     * Get arrays array [].
+     *
+     * @return the array []
+     */
+    @NonNull
+    Array[] getArrays();
+
+    /**
+     * The interface Early stop visitor.
+     */
+    interface EarlyStopVisitor {
+        /**
+         * Stop boolean.
+         *
+         * @return the boolean
+         */
+        boolean stop();
+    }
+
+    /**
+     * The interface Member visitor.
+     */
+    interface MemberVisitor extends EarlyStopVisitor {
+    }
+
+    /**
+     * The interface Class visitor.
+     */
+    interface ClassVisitor extends EarlyStopVisitor {
+        /**
+         * Visit member visitor.
+         */
+        @Nullable
+        MemberVisitor visit(int clazz, int accessFlags, int superClass, @NonNull int[] interfaces,
+                            int sourceFile, @NonNull int[] staticFields,
+                            @NonNull int[] staticFieldsAccessFlags, @NonNull int[] instanceFields,
+                            @NonNull int[] instanceFieldsAccessFlags, @NonNull int[] directMethods,
+                            @NonNull int[] directMethodsAccessFlags, @NonNull int[] virtualMethods,
+                            @NonNull int[] virtualMethodsAccessFlags, @NonNull int[] annotations);
+    }
+
+    /**
+     * The interface Field visitor.
+     */
+    interface FieldVisitor extends MemberVisitor {
+        /**
+         * Visit.
+         */
+        void visit(int field, int accessFlags, @NonNull int[] annotations);
+    }
+
+    /**
+     * The interface Method visitor.
+     */
+    interface MethodVisitor extends MemberVisitor {
+        /**
+         * Visit method body.
+         */
+        @Nullable
+        MethodBodyVisitor visit(int method, int accessFlags, boolean hasBody,
+                                @NonNull int[] annotations, @NonNull int[] parameterAnnotations);
+    }
+
+    /**
+     * The interface Method body visitor.
+     */
+    interface MethodBodyVisitor {
+        /**
+         * Visit.
+         */
+        void visit(int method, int accessFlags, @NonNull int[] referredStrings,
+                   @NonNull int[] invokedMethods, @NonNull int[] accessedFields,
+                   @NonNull int[] assignedFields, @NonNull byte[] opcodes);
+    }
+
+    /**
+     * Visit defined classes.
+     *
+     * @param visitor the visitor
+     * @throws IllegalStateException the illegal state exception
+     */
+    void visitDefinedClasses(@NonNull ClassVisitor visitor) throws IllegalStateException;
+}

--- a/services/daemon-service/src/main/aidl/org/lsposed/lspd/models/PreLoadedApk.aidl
+++ b/services/daemon-service/src/main/aidl/org/lsposed/lspd/models/PreLoadedApk.aidl
@@ -5,4 +5,6 @@ parcelable PreLoadedApk {
     List<String> moduleClassNames;
     List<String> moduleLibraryNames;
     boolean legacy;
+    boolean exceptionPassthrough;
+    int targetApiVersion;
 }

--- a/services/daemon-service/src/main/aidl/org/lsposed/lspd/service/ILSPInjectedModuleService.aidl
+++ b/services/daemon-service/src/main/aidl/org/lsposed/lspd/service/ILSPInjectedModuleService.aidl
@@ -5,6 +5,8 @@ import org.lsposed.lspd.service.IRemotePreferenceCallback;
 interface ILSPInjectedModuleService {
     int getFrameworkPrivilege();
 
+    long getFrameworkProperties();
+
     Bundle requestRemotePreferences(String group, IRemotePreferenceCallback callback);
 
     ParcelFileDescriptor openRemoteFile(String path);


### PR DESCRIPTION
## Hook engine

API 101 hooks (`intercept(Chain)`, `HookBuilder`, and `Invoker`) are placed as an outer chain layer. Their terminal `proceed()` continues into the existing API 100 and classic dispatch flow.

This keeps the original method execution path intact, no matter which API generation creates the hook, the original method is still invoked exactly once.

## Lifecycle

Both API generations share the same hookers, which now dispatch both callback sets:

- API 101 callbacks:
  - `onPackageLoaded`
  - `onSystemServerLoaded`

- API 100/classic callbacks:
  - `onPackageReady`
  - `onSystemServerStarting`

This allows newer modules to use the API 101 lifecycle while keeping older modules fully compatible.

## Module selection

The active wire version is selected per module using `targetApiVersion` from `module.prop`.

API 100 modules do not declare this value, so they continue using the existing behavior without requiring any changes.

## IXposedService

`LSPModuleService` now supports both API 100 and API 101 wire formats through dual-wire `onTransact` handling.

Conflicting transactions are handled for both generations, including:

- Privilege and property requests
- `requestScope`
- `removeScope`

Scope callbacks are also delivered using the wire version selected for each module, ensuring that API 100 and API 101 modules communicate through their expected protocol.

## Transaction code notes

The AGP AIDL compiler does not use the exact transaction numbers declared in `.aidl` files. Explicit values (`= N`) are converted into:

`FIRST_CALL_TRANSACTION + N`

Because both the daemon and modules are built with the same compiler, they normally agree on the generated wire format.

However, dual-wire dispatch must intercept the actual Binder transaction codes, not the values written in the `.aidl` files.

For example:

| AIDL value | Actual Binder code |
| --- | --- |
| `5` | `6` |
| `11` | `12` |
| `12` | `13` |

The dispatcher must therefore handle `6/12/13`, not `5/11/12`.